### PR TITLE
Add Linear documentation import tool

### DIFF
--- a/scripts/linear/.env.example
+++ b/scripts/linear/.env.example
@@ -1,0 +1,11 @@
+# Linear API Configuration
+# Get your API key from: Linear Settings > API > Personal API keys
+
+# Required: Your Linear API key
+LINEAR_API_KEY=lin_api_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Optional: Specific team ID to use (defaults to first team)
+# LINEAR_TEAM_ID=
+
+# Optional: Project name for imported documentation
+# LINEAR_PROJECT_NAME=Ad-Blocking Documentation

--- a/scripts/linear/.gitignore
+++ b/scripts/linear/.gitignore
@@ -1,0 +1,17 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Environment variables (contains secrets)
+.env
+
+# IDE
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log
+npm-debug.log*

--- a/scripts/linear/README.md
+++ b/scripts/linear/README.md
@@ -1,0 +1,174 @@
+# Linear Documentation Import Tool
+
+Import ad-blocking repository documentation into Linear project management system.
+
+## Overview
+
+This tool parses the repository's Linear documentation (`docs/LINEAR_DOCUMENTATION.md`) and imports it into Linear, creating:
+
+- A project to track the ad-blocking system
+- Issues for each roadmap item
+- Documentation issues for each component
+- A main documentation issue with the full content
+
+## Prerequisites
+
+- Node.js 20+
+- npm or yarn
+- Linear account with API access
+
+## Installation
+
+```bash
+cd scripts/linear
+npm install
+npm run build
+```
+
+## Configuration
+
+1. Copy the environment example file:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Get your Linear API key:
+   - Go to **Linear Settings** > **API** > **Personal API keys**
+   - Create a new key with appropriate permissions
+   - Copy the key to your `.env` file
+
+3. Edit `.env` with your configuration:
+   ```env
+   LINEAR_API_KEY=lin_api_your_key_here
+   LINEAR_TEAM_ID=optional_team_id
+   LINEAR_PROJECT_NAME=Ad-Blocking Documentation
+   ```
+
+## Usage
+
+### Import Documentation
+
+```bash
+# Full import with default settings
+npm run import:docs
+
+# Dry run (preview without making changes)
+npm run import:dry-run
+
+# Custom file path
+npm run import -- --file /path/to/documentation.md
+
+# Specify project name
+npm run import -- --project "My Project Name"
+
+# Use specific team
+npm run import -- --team team_id_here
+```
+
+### List Available Resources
+
+```bash
+# List available teams
+npm run import -- --list-teams
+
+# List existing projects
+npm run import -- --list-projects
+```
+
+### Command Options
+
+| Option | Description |
+|--------|-------------|
+| `-f, --file <path>` | Path to markdown documentation file |
+| `-t, --team <id>` | Linear team ID (defaults to first team) |
+| `-p, --project <name>` | Linear project name |
+| `--dry-run` | Preview import without making changes |
+| `--no-project` | Skip project creation |
+| `--no-issues` | Skip issue creation |
+| `--no-docs` | Skip documentation issue creation |
+| `--list-teams` | List available teams and exit |
+| `--list-projects` | List existing projects and exit |
+| `-v, --verbose` | Verbose output |
+
+## What Gets Imported
+
+### Roadmap Items
+
+Roadmap items (checkbox lists in the documentation) are converted to Linear issues:
+
+```markdown
+- [ ] Additional filter sources integration
+- [ ] Real-time filter update notifications
+```
+
+Becomes:
+- Issue: "Additional filter sources integration"
+- Issue: "Real-time filter update notifications"
+
+### Components
+
+Each documented component creates a detailed documentation issue:
+
+- Filter Rules (`/rules/`)
+- Filter Compiler (`/src/filter-compiler/`)
+- Webhook Application (`/src/webhook-app/`)
+- etc.
+
+### Main Documentation
+
+The full documentation content is imported as a comprehensive reference issue.
+
+## Project Structure
+
+```
+scripts/linear/
+├── src/
+│   ├── types.ts          # TypeScript interfaces
+│   ├── parser.ts         # Markdown parsing logic
+│   ├── linear-client.ts  # Linear API wrapper
+│   └── linear-import.ts  # Main entry point
+├── .env.example          # Environment configuration template
+├── package.json          # Dependencies and scripts
+├── tsconfig.json         # TypeScript configuration
+└── README.md             # This file
+```
+
+## Development
+
+### Build
+
+```bash
+npm run build
+```
+
+### Run directly
+
+```bash
+node dist/linear-import.js --help
+```
+
+## Troubleshooting
+
+### "LINEAR_API_KEY environment variable is required"
+
+Ensure you've created a `.env` file with your API key:
+```bash
+cp .env.example .env
+# Edit .env and add your API key
+```
+
+### "No teams found in Linear workspace"
+
+Make sure your API key has access to at least one team in your Linear workspace.
+
+### "Failed to create project"
+
+Check that your API key has permissions to create projects. You may need to use the `--team` option to specify a valid team ID.
+
+### Rate Limiting
+
+Linear has API rate limits. If you encounter rate limiting issues, wait a few minutes and try again.
+
+## License
+
+GPL-3.0 - See [LICENSE](../../LICENSE) for details.

--- a/scripts/linear/package.json
+++ b/scripts/linear/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "linear-import",
+  "version": "1.0.0",
+  "description": "Import documentation into Linear project management",
+  "type": "module",
+  "main": "dist/linear-import.js",
+  "scripts": {
+    "build": "tsc",
+    "import": "node dist/linear-import.js",
+    "import:docs": "node dist/linear-import.js --file ../../docs/LINEAR_DOCUMENTATION.md",
+    "import:dry-run": "node dist/linear-import.js --file ../../docs/LINEAR_DOCUMENTATION.md --dry-run"
+  },
+  "keywords": [
+    "linear",
+    "documentation",
+    "import",
+    "project-management"
+  ],
+  "author": "",
+  "license": "GPL-3.0",
+  "dependencies": {
+    "@linear/sdk": "^24.0.0",
+    "dotenv": "^16.4.5",
+    "marked": "^12.0.2",
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/scripts/linear/src/linear-client.ts
+++ b/scripts/linear/src/linear-client.ts
@@ -1,0 +1,316 @@
+/**
+ * Linear API client wrapper for documentation import
+ */
+
+import { LinearClient, Project, Issue, Team, Document } from "@linear/sdk";
+import {
+  ImportConfig,
+  LinearImportResult,
+  ParsedDocument,
+  RoadmapItem,
+  ComponentInfo,
+} from "./types.js";
+
+export class LinearImporter {
+  private client: LinearClient;
+  private config: ImportConfig;
+  private teamId: string | null = null;
+
+  constructor(apiKey: string, config: ImportConfig) {
+    this.client = new LinearClient({ apiKey });
+    this.config = config;
+  }
+
+  /**
+   * Initialize and validate the Linear connection
+   */
+  async initialize(): Promise<void> {
+    try {
+      const viewer = await this.client.viewer;
+      console.log(`Connected to Linear as: ${viewer.name || viewer.email}`);
+
+      // Get or validate team
+      if (this.config.teamId) {
+        this.teamId = this.config.teamId;
+      } else {
+        const teams = await this.client.teams();
+        if (teams.nodes.length === 0) {
+          throw new Error("No teams found in Linear workspace");
+        }
+        this.teamId = teams.nodes[0].id;
+        console.log(`Using team: ${teams.nodes[0].name}`);
+      }
+    } catch (error) {
+      throw new Error(`Failed to initialize Linear client: ${error}`);
+    }
+  }
+
+  /**
+   * Import documentation into Linear
+   */
+  async importDocumentation(
+    document: ParsedDocument,
+    roadmapItems: RoadmapItem[],
+    components: ComponentInfo[]
+  ): Promise<LinearImportResult> {
+    const result: LinearImportResult = {
+      issuesCreated: 0,
+      documentsCreated: 0,
+      errors: [],
+    };
+
+    if (!this.teamId) {
+      throw new Error("Linear client not initialized. Call initialize() first.");
+    }
+
+    try {
+      // Create or get project
+      let projectId: string | undefined;
+      if (this.config.createProject) {
+        projectId = await this.createOrGetProject(document.title);
+        result.projectId = projectId;
+        result.projectName = this.config.projectName || document.title;
+      }
+
+      // Create roadmap issues
+      if (this.config.createIssues && roadmapItems.length > 0) {
+        console.log(`\nCreating ${roadmapItems.length} roadmap issues...`);
+        for (const item of roadmapItems) {
+          try {
+            if (this.config.dryRun) {
+              console.log(`  [DRY RUN] Would create issue: ${item.title}`);
+              result.issuesCreated++;
+            } else {
+              await this.createIssue(item, projectId);
+              result.issuesCreated++;
+              console.log(`  Created issue: ${item.title}`);
+            }
+          } catch (error) {
+            result.errors.push(`Failed to create issue "${item.title}": ${error}`);
+          }
+        }
+      }
+
+      // Create component documentation issues
+      if (this.config.createIssues && components.length > 0) {
+        console.log(`\nCreating ${components.length} component documentation issues...`);
+        for (const component of components) {
+          try {
+            if (this.config.dryRun) {
+              console.log(`  [DRY RUN] Would create component doc: ${component.name}`);
+              result.documentsCreated++;
+            } else {
+              await this.createComponentIssue(component, projectId);
+              result.documentsCreated++;
+              console.log(`  Created component documentation: ${component.name}`);
+            }
+          } catch (error) {
+            result.errors.push(
+              `Failed to create component doc "${component.name}": ${error}`
+            );
+          }
+        }
+      }
+
+      // Create main documentation issue
+      if (this.config.createDocuments) {
+        console.log(`\nCreating main documentation issue...`);
+        try {
+          if (this.config.dryRun) {
+            console.log(`  [DRY RUN] Would create main documentation issue`);
+            result.documentsCreated++;
+          } else {
+            await this.createMainDocumentationIssue(document, projectId);
+            result.documentsCreated++;
+            console.log(`  Created main documentation issue`);
+          }
+        } catch (error) {
+          result.errors.push(`Failed to create main documentation: ${error}`);
+        }
+      }
+    } catch (error) {
+      result.errors.push(`Import failed: ${error}`);
+    }
+
+    return result;
+  }
+
+  /**
+   * Create or get a project by name
+   */
+  private async createOrGetProject(defaultName: string): Promise<string> {
+    const projectName = this.config.projectName || defaultName;
+
+    // Check if project already exists
+    const projects = await this.client.projects({
+      filter: {
+        name: { eq: projectName },
+      },
+    });
+
+    if (projects.nodes.length > 0) {
+      console.log(`Found existing project: ${projectName}`);
+      return projects.nodes[0].id;
+    }
+
+    // Create new project
+    if (this.config.dryRun) {
+      console.log(`[DRY RUN] Would create project: ${projectName}`);
+      return "dry-run-project-id";
+    }
+
+    const teams = await this.client.teams();
+    const team = teams.nodes.find((t) => t.id === this.teamId) || teams.nodes[0];
+
+    const projectPayload = await this.client.createProject({
+      name: projectName,
+      description: "Ad-blocking system documentation and tracking",
+      teamIds: [team.id],
+    });
+
+    const project = await projectPayload.project;
+    if (!project) {
+      throw new Error("Failed to create project");
+    }
+
+    console.log(`Created project: ${projectName}`);
+    return project.id;
+  }
+
+  /**
+   * Create an issue from a roadmap item
+   */
+  private async createIssue(
+    item: RoadmapItem,
+    projectId?: string
+  ): Promise<void> {
+    const issueInput: {
+      title: string;
+      description: string;
+      teamId: string;
+      projectId?: string;
+    } = {
+      title: item.title,
+      description: item.description || `Roadmap item: ${item.title}`,
+      teamId: this.teamId!,
+    };
+
+    if (projectId) {
+      issueInput.projectId = projectId;
+    }
+
+    await this.client.createIssue(issueInput);
+  }
+
+  /**
+   * Create an issue for component documentation
+   */
+  private async createComponentIssue(
+    component: ComponentInfo,
+    projectId?: string
+  ): Promise<void> {
+    const description = this.formatComponentDescription(component);
+
+    const issueInput: {
+      title: string;
+      description: string;
+      teamId: string;
+      projectId?: string;
+    } = {
+      title: `[Component] ${component.name}`,
+      description,
+      teamId: this.teamId!,
+    };
+
+    if (projectId) {
+      issueInput.projectId = projectId;
+    }
+
+    await this.client.createIssue(issueInput);
+  }
+
+  /**
+   * Create the main documentation issue
+   */
+  private async createMainDocumentationIssue(
+    document: ParsedDocument,
+    projectId?: string
+  ): Promise<void> {
+    // Truncate content if too long for Linear
+    const maxLength = 10000;
+    let content = document.rawContent;
+    if (content.length > maxLength) {
+      content = content.substring(0, maxLength) + "\n\n... (truncated)";
+    }
+
+    const issueInput: {
+      title: string;
+      description: string;
+      teamId: string;
+      projectId?: string;
+    } = {
+      title: `[Documentation] ${document.title}`,
+      description: content,
+      teamId: this.teamId!,
+    };
+
+    if (projectId) {
+      issueInput.projectId = projectId;
+    }
+
+    await this.client.createIssue(issueInput);
+  }
+
+  /**
+   * Format component info as markdown description
+   */
+  private formatComponentDescription(component: ComponentInfo): string {
+    let description = `## ${component.name}\n\n`;
+    description += `**Path:** \`${component.path}\`\n\n`;
+
+    if (component.purpose) {
+      description += `**Purpose:** ${component.purpose}\n\n`;
+    }
+
+    if (component.techStack.length > 0) {
+      description += `### Technology Stack\n`;
+      for (const tech of component.techStack) {
+        description += `- ${tech}\n`;
+      }
+      description += "\n";
+    }
+
+    if (component.keyFiles.length > 0) {
+      description += `### Key Files\n`;
+      description += "| File | Description |\n";
+      description += "|------|-------------|\n";
+      for (const file of component.keyFiles) {
+        description += `| \`${file.file}\` | ${file.description} |\n`;
+      }
+    }
+
+    return description;
+  }
+
+  /**
+   * List available teams
+   */
+  async listTeams(): Promise<Array<{ id: string; name: string }>> {
+    const teams = await this.client.teams();
+    return teams.nodes.map((team) => ({
+      id: team.id,
+      name: team.name,
+    }));
+  }
+
+  /**
+   * List existing projects
+   */
+  async listProjects(): Promise<Array<{ id: string; name: string }>> {
+    const projects = await this.client.projects();
+    return projects.nodes.map((project) => ({
+      id: project.id,
+      name: project.name,
+    }));
+  }
+}

--- a/scripts/linear/src/linear-import.ts
+++ b/scripts/linear/src/linear-import.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Linear Documentation Import Tool
+ *
+ * Import ad-blocking repository documentation into Linear project management.
+ *
+ * Usage:
+ *   npm run import:docs          # Import documentation with default settings
+ *   npm run import:dry-run       # Preview what would be imported
+ *
+ * Environment Variables:
+ *   LINEAR_API_KEY     - Your Linear API key (required)
+ *   LINEAR_TEAM_ID     - Team ID to use (optional, defaults to first team)
+ *   LINEAR_PROJECT_NAME - Project name (optional, defaults to document title)
+ */
+
+import { Command } from "commander";
+import { config } from "dotenv";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { existsSync } from "fs";
+
+import { LinearImporter } from "./linear-client.js";
+import {
+  parseMarkdownFile,
+  extractRoadmapItems,
+  extractComponents,
+  flattenSections,
+} from "./parser.js";
+import { ImportConfig } from "./types.js";
+
+// Load environment variables
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: resolve(__dirname, "../.env") });
+
+const DEFAULT_DOC_PATH = resolve(__dirname, "../../../docs/LINEAR_DOCUMENTATION.md");
+
+async function main(): Promise<void> {
+  const program = new Command();
+
+  program
+    .name("linear-import")
+    .description("Import documentation into Linear project management")
+    .version("1.0.0")
+    .option("-f, --file <path>", "Path to markdown documentation file", DEFAULT_DOC_PATH)
+    .option("-t, --team <id>", "Linear team ID (defaults to first team)")
+    .option("-p, --project <name>", "Linear project name")
+    .option("--dry-run", "Preview import without making changes", false)
+    .option("--no-project", "Skip project creation")
+    .option("--no-issues", "Skip issue creation")
+    .option("--no-docs", "Skip documentation issue creation")
+    .option("--list-teams", "List available teams and exit")
+    .option("--list-projects", "List existing projects and exit")
+    .option("-v, --verbose", "Verbose output")
+    .parse(process.argv);
+
+  const options = program.opts();
+
+  // Check for API key
+  const apiKey = process.env.LINEAR_API_KEY;
+  if (!apiKey) {
+    console.error("Error: LINEAR_API_KEY environment variable is required");
+    console.error("\nTo get your API key:");
+    console.error("1. Go to Linear Settings > API");
+    console.error("2. Create a new personal API key");
+    console.error("3. Set it in your .env file or environment");
+    process.exit(1);
+  }
+
+  const importConfig: ImportConfig = {
+    teamId: options.team || process.env.LINEAR_TEAM_ID || "",
+    projectName: options.project || process.env.LINEAR_PROJECT_NAME || "",
+    createProject: options.project !== false,
+    createIssues: options.issues !== false,
+    createDocuments: options.docs !== false,
+    dryRun: options.dryRun,
+  };
+
+  try {
+    const importer = new LinearImporter(apiKey, importConfig);
+    await importer.initialize();
+
+    // Handle list commands
+    if (options.listTeams) {
+      console.log("\nAvailable Teams:");
+      const teams = await importer.listTeams();
+      for (const team of teams) {
+        console.log(`  ${team.name} (${team.id})`);
+      }
+      return;
+    }
+
+    if (options.listProjects) {
+      console.log("\nExisting Projects:");
+      const projects = await importer.listProjects();
+      if (projects.length === 0) {
+        console.log("  No projects found");
+      } else {
+        for (const project of projects) {
+          console.log(`  ${project.name} (${project.id})`);
+        }
+      }
+      return;
+    }
+
+    // Validate file exists
+    const filePath = resolve(options.file);
+    if (!existsSync(filePath)) {
+      console.error(`Error: Documentation file not found: ${filePath}`);
+      process.exit(1);
+    }
+
+    console.log(`\nParsing documentation: ${filePath}`);
+    const document = parseMarkdownFile(filePath);
+    console.log(`  Title: ${document.title}`);
+
+    // Extract data from document
+    const roadmapItems = extractRoadmapItems(document);
+    const components = extractComponents(document);
+    const sections = flattenSections(document);
+
+    if (options.verbose) {
+      console.log(`\n  Sections: ${sections.length}`);
+      console.log(`  Roadmap items: ${roadmapItems.length}`);
+      console.log(`  Components: ${components.length}`);
+    }
+
+    console.log("\nRoadmap Items:");
+    for (const item of roadmapItems) {
+      const status = item.completed ? "[x]" : "[ ]";
+      console.log(`  ${status} ${item.title}`);
+    }
+
+    console.log("\nComponents:");
+    for (const component of components) {
+      console.log(`  - ${component.name} (${component.path})`);
+    }
+
+    if (importConfig.dryRun) {
+      console.log("\n=== DRY RUN MODE - No changes will be made ===\n");
+    }
+
+    // Perform import
+    console.log("\nStarting import...");
+    const result = await importer.importDocumentation(
+      document,
+      roadmapItems,
+      components
+    );
+
+    // Print results
+    console.log("\n=== Import Results ===");
+    if (result.projectId) {
+      console.log(`Project: ${result.projectName} (${result.projectId})`);
+    }
+    console.log(`Issues created: ${result.issuesCreated}`);
+    console.log(`Documents created: ${result.documentsCreated}`);
+
+    if (result.errors.length > 0) {
+      console.log(`\nErrors (${result.errors.length}):`);
+      for (const error of result.errors) {
+        console.log(`  - ${error}`);
+      }
+    }
+
+    console.log("\nImport complete!");
+  } catch (error) {
+    console.error(`\nError: ${error}`);
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/scripts/linear/src/parser.ts
+++ b/scripts/linear/src/parser.ts
@@ -1,0 +1,246 @@
+/**
+ * Markdown documentation parser for Linear import
+ */
+
+import { readFileSync } from "fs";
+import {
+  DocumentSection,
+  ParsedDocument,
+  RoadmapItem,
+  ComponentInfo,
+} from "./types.js";
+
+/**
+ * Parse a markdown file into structured sections
+ */
+export function parseMarkdownFile(filePath: string): ParsedDocument {
+  const rawContent = readFileSync(filePath, "utf-8");
+  return parseMarkdown(rawContent);
+}
+
+/**
+ * Parse markdown content into structured sections
+ */
+export function parseMarkdown(content: string): ParsedDocument {
+  const lines = content.split("\n");
+  const sections: DocumentSection[] = [];
+  let title = "";
+
+  let currentSection: DocumentSection | null = null;
+  const sectionStack: DocumentSection[] = [];
+  let contentBuffer: string[] = [];
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+
+    if (headingMatch) {
+      // Save accumulated content to current section
+      if (currentSection) {
+        currentSection.content = contentBuffer.join("\n").trim();
+      }
+      contentBuffer = [];
+
+      const level = headingMatch[1].length;
+      const sectionTitle = headingMatch[2];
+
+      // First h1 is the document title
+      if (level === 1 && !title) {
+        title = sectionTitle;
+        continue;
+      }
+
+      const newSection: DocumentSection = {
+        title: sectionTitle,
+        level,
+        content: "",
+        subsections: [],
+      };
+
+      // Find parent section
+      while (
+        sectionStack.length > 0 &&
+        sectionStack[sectionStack.length - 1].level >= level
+      ) {
+        sectionStack.pop();
+      }
+
+      if (sectionStack.length === 0) {
+        sections.push(newSection);
+      } else {
+        sectionStack[sectionStack.length - 1].subsections.push(newSection);
+      }
+
+      sectionStack.push(newSection);
+      currentSection = newSection;
+    } else {
+      contentBuffer.push(line);
+    }
+  }
+
+  // Save final content
+  if (currentSection) {
+    currentSection.content = contentBuffer.join("\n").trim();
+  }
+
+  return {
+    title,
+    sections,
+    rawContent: content,
+  };
+}
+
+/**
+ * Extract roadmap items from parsed document
+ */
+export function extractRoadmapItems(document: ParsedDocument): RoadmapItem[] {
+  const roadmapItems: RoadmapItem[] = [];
+
+  function findRoadmapSection(sections: DocumentSection[]): DocumentSection | null {
+    for (const section of sections) {
+      if (
+        section.title.toLowerCase().includes("roadmap") ||
+        section.title.toLowerCase().includes("future work")
+      ) {
+        return section;
+      }
+      const found = findRoadmapSection(section.subsections);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  const roadmapSection = findRoadmapSection(document.sections);
+  if (!roadmapSection) return roadmapItems;
+
+  // Parse checkbox items from roadmap section
+  const content = roadmapSection.content +
+    roadmapSection.subsections.map(s => s.content).join("\n");
+
+  const checkboxRegex = /^-\s*\[([ x])\]\s*(.+)$/gm;
+  let match;
+
+  while ((match = checkboxRegex.exec(content)) !== null) {
+    roadmapItems.push({
+      title: match[2].trim(),
+      description: "",
+      completed: match[1] === "x",
+    });
+  }
+
+  return roadmapItems;
+}
+
+/**
+ * Extract component information from parsed document
+ */
+export function extractComponents(document: ParsedDocument): ComponentInfo[] {
+  const components: ComponentInfo[] = [];
+
+  function findComponentsSection(sections: DocumentSection[]): DocumentSection | null {
+    for (const section of sections) {
+      if (section.title.toLowerCase() === "components") {
+        return section;
+      }
+      const found = findComponentsSection(section.subsections);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  const componentsSection = findComponentsSection(document.sections);
+  if (!componentsSection) return components;
+
+  for (const subsection of componentsSection.subsections) {
+    // Parse component info from subsection
+    const pathMatch = subsection.title.match(/\(([^)]+)\)/);
+    const nameMatch = subsection.title.match(/^\d+\.\s*(.+?)(?:\s*\(|$)/);
+
+    const component: ComponentInfo = {
+      name: nameMatch ? nameMatch[1].trim() : subsection.title,
+      path: pathMatch ? pathMatch[1] : "",
+      purpose: "",
+      techStack: [],
+      keyFiles: [],
+    };
+
+    // Extract purpose from content
+    const purposeMatch = subsection.content.match(/\*\*Purpose:\*\*\s*(.+)/);
+    if (purposeMatch) {
+      component.purpose = purposeMatch[1].trim();
+    }
+
+    // Extract tech stack from content
+    const techStackSection = subsection.content.match(
+      /\*\*Technology Stack:\*\*\n([\s\S]*?)(?=\n\*\*|\n---|\n###|$)/
+    );
+    if (techStackSection) {
+      const techItems = techStackSection[1].match(/^-\s+(.+)/gm);
+      if (techItems) {
+        component.techStack = techItems.map((item) =>
+          item.replace(/^-\s+/, "").trim()
+        );
+      }
+    }
+
+    // Extract key files from tables
+    const tableMatch = subsection.content.match(
+      /\| File \| Description \|\n\|[-\s|]+\|\n([\s\S]*?)(?=\n\n|\n---|\n###|$)/
+    );
+    if (tableMatch) {
+      const rows = tableMatch[1].split("\n").filter((row) => row.trim());
+      for (const row of rows) {
+        const cells = row.split("|").filter((cell) => cell.trim());
+        if (cells.length >= 2) {
+          component.keyFiles.push({
+            file: cells[0].replace(/`/g, "").trim(),
+            description: cells[1].trim(),
+          });
+        }
+      }
+    }
+
+    components.push(component);
+  }
+
+  return components;
+}
+
+/**
+ * Get section by title path (e.g., "Components/Filter Rules")
+ */
+export function getSectionByPath(
+  document: ParsedDocument,
+  path: string
+): DocumentSection | null {
+  const parts = path.split("/");
+  let sections = document.sections;
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i].toLowerCase();
+    const found = sections.find((s) =>
+      s.title.toLowerCase().includes(part)
+    );
+    if (!found) return null;
+    if (i === parts.length - 1) return found;
+    sections = found.subsections;
+  }
+
+  return null;
+}
+
+/**
+ * Flatten all sections into a single array
+ */
+export function flattenSections(document: ParsedDocument): DocumentSection[] {
+  const result: DocumentSection[] = [];
+
+  function flatten(sections: DocumentSection[]): void {
+    for (const section of sections) {
+      result.push(section);
+      flatten(section.subsections);
+    }
+  }
+
+  flatten(document.sections);
+  return result;
+}

--- a/scripts/linear/src/types.ts
+++ b/scripts/linear/src/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Types for Linear documentation import
+ */
+
+export interface DocumentSection {
+  title: string;
+  level: number;
+  content: string;
+  subsections: DocumentSection[];
+}
+
+export interface ParsedDocument {
+  title: string;
+  sections: DocumentSection[];
+  rawContent: string;
+}
+
+export interface ImportConfig {
+  teamId: string;
+  projectName: string;
+  createProject: boolean;
+  createIssues: boolean;
+  createDocuments: boolean;
+  dryRun: boolean;
+}
+
+export interface RoadmapItem {
+  title: string;
+  description: string;
+  completed: boolean;
+}
+
+export interface ComponentInfo {
+  name: string;
+  path: string;
+  purpose: string;
+  techStack: string[];
+  keyFiles: Array<{ file: string; description: string }>;
+}
+
+export interface LinearImportResult {
+  projectId?: string;
+  projectName?: string;
+  issuesCreated: number;
+  documentsCreated: number;
+  errors: string[];
+}

--- a/scripts/linear/tsconfig.json
+++ b/scripts/linear/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Create a TypeScript-based tool to import repository documentation into
Linear project management system. Features include:

- Markdown parser to extract sections, roadmap items, and components
- Linear API client wrapper for project and issue creation
- Support for dry-run mode to preview imports
- CLI with configurable options for team, project, and content selection
- Environment-based configuration for API credentials

Usage: cd scripts/linear && npm install && npm run build && npm run import:docs