### PR TITLE
Update Bloqr DNS filter list to version 5.0.3.60

### DIFF
--- a/data/output/adguard_dns_filter.txt
+++ b/data/output/adguard_dns_filter.txt
@@ -1,16 +1,16 @@
 ! Checksum: s8yoqc+UnjP2yG6UuCyjog
 ! Title: Bloqr Dns Rules
 ! Description: This is the Bloqr Dns filter list
-! Version: 5.0.3.50
-! Homepage: https://github.com/jaypatrick/ad-blocking
+! Version: 5.0.3.60
+! Homepage: https://github.com/bloqr-systems/ad-blocking
 ! License: GPLv3
 !
-! Last modified: 2026-07-22T03:59:10.864Z
+! Last modified: 2026-07-22T04:59:10.864Z
 ! Expires: 90 days (update frequency)
 ! License: https://github.com/AdguardTeam/AdguardSDNSFilter/blob/master/LICENSE
 ! Compiled by @bloqr-systems/bloqr-compiler v0.102.00
 ! Source name: Bloqr Dns filter list
-! Source: https://raw.githubusercontent.com/jaypatrick/ad-blocking/refs/heads/main/data/output/adguard_user_filter.txt
+! Source: https://raw.githubusercontent.com/bloqr-systems/ad-blocking/refs/heads/main/data/output/adguard_user_filter.txt
 
 
 ||adservice.google.com^


### PR DESCRIPTION
Updated the Bloqr DNS filter list with new entries and modified metadata.