### PR TITLE
Fix CI failures on main and modernize workflow triggers

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,8 +7,18 @@ concurrency:
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - 'Dockerfile.warp'
+      - 'docker-compose.yml'
+      - '.dockerignore'
+      - '.github/workflows/docker-image.yml'
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'Dockerfile.warp'
+      - 'docker-compose.yml'
+      - '.dockerignore'
+      - '.github/workflows/docker-image.yml'
 
 jobs:
 

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -62,4 +62,12 @@ jobs:
         run: deno publish --dry-run
 
       - name: Publish to JSR
+        id: publish
+        continue-on-error: true
         run: deno publish
+
+      - name: Report unlinked-package failure
+        if: steps.publish.outcome == 'failure'
+        run: |
+          echo "::warning::deno publish failed. This is expected until @jk-com/adblock-compiler is linked to this GitHub repository via https://jsr.io (one-time manual setup, see the comment at the top of this workflow). Failing the job so it stays visible."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,7 +268,7 @@ jobs:
             - Windows: `.\AdGuard.ConsoleUI.exe`, `.\RulesCompiler.Console.exe`, or `.\rules-compiler.exe`
             - Linux/macOS: `./AdGuard.ConsoleUI`, `./RulesCompiler.Console`, or `./rules-compiler`
 
-            For detailed documentation, see the [README](https://github.com/Bloqr-Systems/bloqr-lists/blob/main/README.md).
+            For detailed documentation, see the [README](https://github.com/BloqrAI/bloqr-lists/blob/main/README.md).
           draft: false
           prerelease: false
         env:

--- a/.github/workflows/validation-compliance.yml
+++ b/.github/workflows/validation-compliance.yml
@@ -89,7 +89,7 @@ jobs:
           echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
 
           # TypeScript
-          if grep -rq "rules.*validator" src/adblock-compiler-core/package.json 2>/dev/null; then
+          if grep -rq "rules.*validator" src/adblock-compiler-core/deno.json 2>/dev/null; then
             echo "| TypeScript | integrated |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| TypeScript | pending |" >> $GITHUB_STEP_SUMMARY

--- a/src/website/package-lock.json
+++ b/src/website/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.48.0",
         "prettier": "^3.9.6"
       },
       "engines": {
@@ -3895,6 +3896,22 @@
       },
       "peerDependencies": {
         "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -14737,6 +14754,53 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",


### PR DESCRIPTION
## Summary

Investigated the three real CI failures on `main` at the latest commit (`5067bb7`, #280) and fixed what's fixable from workflow/repo code, plus did a review pass over the rest of `.github/workflows/`.

**Failures found (of 11 workflows that ran on `main`, 3 failed):**

| Workflow | Cause | Fix |
|---|---|---|
| `gatsby.yml` | `npm ci` failed — `src/website/package-lock.json` was out of sync with `package.json` (missing `@playwright/test`, `playwright`, `fsevents` entries added by the Playwright E2E setup PR #282) | Regenerated the lock file; verified `npm ci` and `npm run build` both succeed locally |
| `publish-jsr.yml` | `deno publish` fails with `InvalidIssuer` — the `@jk-com/adblock-compiler` JSR package hasn't been linked to this GitHub repo yet via jsr.io | **Cannot be fixed from a workflow file** — it's a one-time manual linking step on jsr.io (already documented in the workflow's header comment). Added a clearer `::warning::` annotation so the cause stays obvious instead of a bare OIDC stack trace. |
| `CodeQL` (dynamic/`github-code-scanning`) | `startup_failure` — GitHub's repo-level "default setup" CodeQL is colliding with the advanced CodeQL job already defined in `security.yml` | **Cannot be fixed from a workflow file** — needs default setup disabled in *Settings → Code security → Code scanning* for this repo. |

The other 8 workflows (Rust, .NET, Python, PowerShell, TypeScript/Deno, Docker, build-scripts-tests, validation-compliance) were already green on `main`.

**adblock-compiler-core CI:** already has proper coverage via `typescript.yml` (type check, lint, fmt check, test) and `publish-jsr.yml` (dry-run publish + real publish gated on the JSR linking above), both added in #280. No gaps found there.

**Workflow review / modernization / pruning:**
- No unused or orphaned workflows found — every workflow's path triggers reference directories that exist in the current tree (no leftover `rules-compiler-typescript` references from the #280 rename).
- `docker-image.yml` had no path filters, so it ran on every push/PR regardless of whether `Dockerfile.warp` changed — added path filters matching the pattern used by every other workflow.
- `validation-compliance.yml`'s integration-status check looked for `src/adblock-compiler-core/package.json`, which doesn't exist (it's Deno-based) — fixed to check `deno.json`, so the step summary reports accurately instead of always saying "pending".
- `release.yml` had a stale `Bloqr-Systems` org reference in the generated release notes body — fixed to `BloqrAI`.

## Test plan
- [x] `npm ci` succeeds in `src/website` with the regenerated lock file
- [x] `npm run build` succeeds in `src/website`
- [x] All workflow YAML files parse successfully
- [ ] CI green on this PR (watching)
- [ ] Manual: disable CodeQL default setup in repo settings
- [ ] Manual: link `@jk-com/adblock-compiler` on jsr.io to this repo


---
_Generated by [Claude Code](https://claude.ai/code/session_01PbdgZmuyyLWAaYHEzT5Sac)_