### PR TITLE
Add CI guard against stale pre-rename/retired-scope references

### DIFF
--- a/.github/workflows/stale-reference-check.yml
+++ b/.github/workflows/stale-reference-check.yml
@@ -1,0 +1,40 @@
+name: Stale Reference Check
+
+# Guards against regression of stale references that have already been
+# cleaned up once (see bloqr-core#257): the repo's pre-rename GitHub path
+# and its retired JSR scope. Grep-based by design — cheap, fast, and
+# explicit about what it's checking for. This file itself is excluded from
+# both checks since it necessarily names the patterns it's guarding against.
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+jobs:
+  check:
+    name: Grep for stale references
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: No pre-rename repo path references
+        env:
+          STALE_PATH: jaypatrick/ad-blocking
+        run: |
+          if grep -rn "$STALE_PATH" --include="*.md" --include="*.json" --include="*.js" --include="*.ts" --include="*.cs" --include="*.py" --include="*.rs" --include="*.yml" --include="*.yaml" . \
+              | grep -v "^./.github/workflows/stale-reference-check.yml:" ; then
+            echo "::error::Found a reference to the pre-rename repo path. Update it to the current repo location."
+            exit 1
+          fi
+
+      - name: No retired JSR scope references
+        env:
+          STALE_SCOPE: jk-com
+        run: |
+          if grep -rln "$STALE_SCOPE" --include="*.md" --include="*.json" --include="*.js" --include="*.ts" --include="*.cs" --include="*.py" --include="*.rs" --include="*.yml" --include="*.yaml" . \
+              | grep -vFx -e "./src/adblock-compiler-core/README.md" -e "./src/adblock-compiler-core/CHANGELOG.md" -e "./docs/adr/0001-canonical-rules-compilation-engine.md" -e "./.github/workflows/stale-reference-check.yml" ; then
+            echo "::error::Found a reference to the retired JSR scope outside the historical-record files where it's expected. Update it to @bloqr."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Small follow-up closing the regression-prevention ask from #257 (now closed): adds `.github/workflows/stale-reference-check.yml`, a grep-based CI guard that fails the build if the pre-rename repo path (`jaypatrick/ad-blocking`) or the retired `@jk-com` JSR scope reappear anywhere outside the historical CHANGELOG/README/ADR entries that intentionally reference them for context.

## Context

While closing out epic #256's readiness sub-issues (#257, #258, #259, #279) and updating #252/#253 with current restructuring status, this was the one concrete piece of unfinished work: #257 explicitly asked for "a lightweight CI check (grep-based is fine) that fails if `jaypatrick/ad-blocking` reappears" and it hadn't been added yet.

## Test plan

- [x] Ran both grep checks locally against the current tree — pass cleanly (the one local false-positive, a gitignored `obj/` build artifact, isn't tracked by git and won't exist in a fresh CI checkout)
- [x] Validated the YAML syntax
- [x] Verified the workflow doesn't self-match its own pattern strings (excluded its own path from both checks)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Njq8s2j9cXsSBoYMjocwHN)_