### PR TITLE
Establish org-wide per-package JSR versioning strategy

### DIFF
--- a/.github/workflows/compiler-core-create-version-tag.yml
+++ b/.github/workflows/compiler-core-create-version-tag.yml
@@ -1,0 +1,113 @@
+name: compiler-core Create Version Tag
+
+# Tags a compiler-core release once its version-bump PR merges. Triggers
+# publish-jsr.yml indirectly: that workflow already runs on any push to
+# src/adblock-compiler-core/** on main, and deno publish is idempotent, so
+# the merged version-bump commit itself is what actually triggers the
+# publish — this workflow's job is purely to record the release point as a
+# git tag for traceability (compiler-core-v1.2.3), matching the tag-per-
+# package convention documented in docs/architecture/versioning-strategy.md.
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag (e.g. 1.2.3). Leave empty to read from deno.json.'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    name: Create compiler-core Version Tag
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' || (
+          github.event.pull_request.merged == true &&
+          startsWith(github.event.pull_request.head.ref, 'auto-version-bump-compiler-core-')
+      )
+    defaults:
+      run:
+        working-directory: src/adblock-compiler-core
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Get version from deno.json
+        id: get_version
+        env:
+          MANUAL_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -n "${MANUAL_VERSION}" ]; then
+            if ! echo "${MANUAL_VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "::error::Invalid version format '${MANUAL_VERSION}'. Expected X.Y.Z."
+              exit 1
+            fi
+            VERSION="${MANUAL_VERSION}"
+          else
+            VERSION=$(deno eval "console.log(JSON.parse(Deno.readTextFileSync('deno.json')).version)")
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=compiler-core-v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check_tag
+        env:
+          TAG: ${{ steps.get_version.outputs.tag }}
+        run: |
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          TAG_NAME: ${{ steps.get_version.outputs.tag }}
+          VERSION: ${{ steps.get_version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG_NAME" -m "compiler-core release $VERSION"
+          git push origin "$TAG_NAME"
+
+      - name: Delete version bump branch
+        if: steps.check_tag.outputs.exists == 'false' && github.event_name == 'pull_request'
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git push origin --delete "$BRANCH_NAME" || echo "Branch already deleted"
+
+      - name: Summary
+        env:
+          TAG: ${{ steps.get_version.outputs.tag }}
+          VERSION: ${{ steps.get_version.outputs.version }}
+          ALREADY_EXISTS: ${{ steps.check_tag.outputs.exists }}
+        run: |
+          if [ "$ALREADY_EXISTS" = "true" ]; then
+            echo "## ℹ️ Tag $TAG already exists, skipped" >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat <<EOF >> "$GITHUB_STEP_SUMMARY"
+          ## 🏷️ compiler-core Version Tag Created
+          - **Version**: $VERSION
+          - **Tag**: $TAG
+
+          publish-jsr.yml publishes this version to JSR on the next push to \`src/adblock-compiler-core/**\` on main (already satisfied by the version-bump merge itself).
+          EOF
+          fi

--- a/.github/workflows/compiler-core-version-bump.yml
+++ b/.github/workflows/compiler-core-version-bump.yml
@@ -1,0 +1,239 @@
+name: compiler-core Version Bump
+
+# Auto-bumps @bloqr/compiler-core's version from Conventional Commits, scoped
+# to src/adblock-compiler-core/**. This is the reference implementation of
+# BloqrAI's per-package JSR versioning standard — see
+# docs/architecture/versioning-strategy.md. As bloqr-core decomposes into
+# more JSR packages, each new package gets its own copy of this workflow
+# (own path filter, own tag prefix, own bump-commit marker) rather than one
+# repo-wide version.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/adblock-compiler-core/**'
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type (leave empty for auto-detect from commits)'
+        required: false
+        type: choice
+        options:
+          - ''
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  version-bump:
+    name: Version Bump
+    runs-on: ubuntu-latest
+    # Skip on the bump commit itself and on any push authored by the bot, to
+    # avoid infinite loops (the bump PR's own merge would otherwise re-trigger
+    # this workflow).
+    if: |
+      github.event_name == 'workflow_dispatch' || (
+          github.event.head_commit &&
+          !contains(github.event.head_commit.message, '[skip ci]') &&
+          !contains(github.event.head_commit.message, '[skip version]') &&
+          github.event.head_commit.author.name != 'github-actions[bot]'
+      )
+    outputs:
+      old_version: ${{ steps.bump.outputs.old }}
+      new_version: ${{ steps.bump.outputs.new }}
+      bump_type: ${{ steps.determine_bump.outputs.bump_type }}
+    defaults:
+      run:
+        working-directory: src/adblock-compiler-core
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history required: git log --grep searches all commits to find the last bump
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Determine version bump type
+        id: determine_bump
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ inputs.bump_type }}" ]; then
+            echo "bump_type=${{ inputs.bump_type }}" >> "$GITHUB_OUTPUT"
+            echo "Using manual bump type: ${{ inputs.bump_type }}"
+            exit 0
+          fi
+
+          # Last compiler-core bump commit (this package's own marker, distinct
+          # from other packages' bump commits so each package's history search
+          # doesn't cross-contaminate).
+          LAST_VERSION_COMMIT=$(git log --grep="chore: bump compiler-core version" --format="%H" -n 1 || echo "")
+          if [ -z "$LAST_VERSION_COMMIT" ]; then
+            LAST_VERSION_COMMIT=$(git rev-list --max-parents=0 HEAD)
+          fi
+          echo "Analyzing commits since $LAST_VERSION_COMMIT"
+
+          # Only consider commits that actually touched this package's directory.
+          CHANGED_SRC=$(git diff --name-only "$LAST_VERSION_COMMIT"..HEAD -- 'src/adblock-compiler-core/src/' | grep -E '\.ts$' | grep -v '\.test\.ts$' || true)
+          if [ -z "$CHANGED_SRC" ]; then
+            echo "No compiler-core source files changed, skipping version bump"
+            echo "bump_type=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "compiler-core source files changed:"
+          echo "$CHANGED_SRC"
+
+          COMMITS=$(git log --format="%s" "$LAST_VERSION_COMMIT"..HEAD -- 'src/adblock-compiler-core/' || echo "")
+          if [ -z "$COMMITS" ]; then
+            echo "No commits to analyze, skipping version bump"
+            echo "bump_type=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BUMP_TYPE="none"
+          while IFS= read -r commit; do
+            echo "Analyzing commit: $commit"
+            if echo "$commit" | grep -qiE "^(feat|fix|perf|refactor)!:|BREAKING CHANGE:"; then
+              BUMP_TYPE="major"
+              echo "Found breaking change: $commit"
+              break
+            fi
+            if echo "$commit" | grep -qiE "^feat(\(.+\))?:"; then
+              if [ "$BUMP_TYPE" != "major" ]; then
+                BUMP_TYPE="minor"
+                echo "Found feature: $commit"
+              fi
+            fi
+            if echo "$commit" | grep -qiE "^fix(\(.+\))?:|^perf(\(.+\))?:"; then
+              if [ "$BUMP_TYPE" != "major" ] && [ "$BUMP_TYPE" != "minor" ]; then
+                BUMP_TYPE="patch"
+                echo "Found fix/perf: $commit"
+              fi
+            fi
+          done <<< "$COMMITS"
+
+          echo "Determined bump type: $BUMP_TYPE"
+          echo "bump_type=$BUMP_TYPE" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version
+        id: bump
+        if: steps.determine_bump.outputs.bump_type != 'none'
+        run: |
+          set -euo pipefail
+          BUMP_TYPE="${{ steps.determine_bump.outputs.bump_type }}"
+
+          OLD=$(deno eval "console.log(JSON.parse(Deno.readTextFileSync('deno.json')).version)")
+          echo "old=$OLD" >> "$GITHUB_OUTPUT"
+
+          IFS='.' read -r major minor patch <<< "$OLD"
+          case "$BUMP_TYPE" in
+            major) NEW="$((major + 1)).0.0" ;;
+            minor) NEW="$major.$((minor + 1)).0" ;;
+            patch) NEW="$major.$minor.$((patch + 1))" ;;
+            *) echo "Error: Unknown bump type '$BUMP_TYPE'" >&2; exit 1 ;;
+          esac
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          echo "Bumping version: $OLD → $NEW ($BUMP_TYPE)"
+
+          sed -i "s/VERSION = '[^']*'/VERSION = '$NEW'/" src/version.ts
+          deno run --allow-read --allow-write scripts/sync-version.ts
+
+      - name: Update CHANGELOG.md
+        if: steps.determine_bump.outputs.bump_type != 'none'
+        run: |
+          set -euo pipefail
+          NEW_VERSION="${{ steps.bump.outputs.new }}"
+          LAST_VERSION_COMMIT=$(git log --grep="chore: bump compiler-core version" --format="%H" -n 1 || echo "")
+          if [ -z "$LAST_VERSION_COMMIT" ]; then
+            LAST_VERSION_COMMIT=$(git rev-list --max-parents=0 HEAD)
+          fi
+
+          ENTRY="## [${NEW_VERSION}] - $(date +%Y-%m-%d)"$'\n'
+          FEATURES=$(git log --format="%s" "$LAST_VERSION_COMMIT"..HEAD -- 'src/adblock-compiler-core/' | grep -E "^feat(\(.+\))?:" | sed 's/^feat(\([^)]*\)): \(.*\)/- **\1**: \2/' | sed 's/^feat: /- /' || echo "")
+          FIXES=$(git log --format="%s" "$LAST_VERSION_COMMIT"..HEAD -- 'src/adblock-compiler-core/' | grep -E "^fix(\(.+\))?:" | sed 's/^fix(\([^)]*\)): \(.*\)/- **\1**: \2/' | sed 's/^fix: /- /' || echo "")
+
+          if [ -n "$FEATURES" ]; then ENTRY="$ENTRY"$'\n'"### Added"$'\n\n'"$FEATURES"$'\n'; fi
+          if [ -n "$FIXES" ]; then ENTRY="$ENTRY"$'\n'"### Fixed"$'\n\n'"$FIXES"$'\n'; fi
+
+          if [ -f CHANGELOG.md ] && grep -q "^## \[" CHANGELOG.md; then
+            FIRST_VERSION_LINE=$(set +o pipefail; grep -n "^## \[" CHANGELOG.md | grep -v "## \[Unreleased\]" | head -1 | cut -d: -f1)
+            if [ -n "$FIRST_VERSION_LINE" ] && [ "$FIRST_VERSION_LINE" -gt 0 ]; then
+              { head -n $((FIRST_VERSION_LINE - 1)) CHANGELOG.md; echo "$ENTRY"; tail -n +$FIRST_VERSION_LINE CHANGELOG.md; } > CHANGELOG.md.tmp
+              mv CHANGELOG.md.tmp CHANGELOG.md
+            else
+              echo "$ENTRY" >> CHANGELOG.md
+            fi
+          elif [ -f CHANGELOG.md ]; then
+            echo "$ENTRY" >> CHANGELOG.md
+          fi
+
+      - name: Create PR with version bump
+        if: steps.determine_bump.outputs.bump_type != 'none'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet; then
+            echo "No changes detected"
+            exit 0
+          fi
+
+          BRANCH_NAME="auto-version-bump-compiler-core-${{ steps.bump.outputs.new }}"
+          git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+          git checkout -b "$BRANCH_NAME"
+          git add deno.json src/version.ts CHANGELOG.md
+          git commit -m "chore: bump compiler-core version to ${{ steps.bump.outputs.new }}"
+          git push -u origin "$BRANCH_NAME"
+
+          gh pr create \
+            --title "chore: bump @bloqr/compiler-core version to ${{ steps.bump.outputs.new }}" \
+            --body "$(cat <<EOF
+          ## compiler-core Version Bump
+
+          This PR was automatically created by the compiler-core Version Bump workflow.
+
+          - **Old Version**: ${{ steps.bump.outputs.old }}
+          - **New Version**: ${{ steps.bump.outputs.new }}
+          - **Bump Type**: ${{ steps.determine_bump.outputs.bump_type }}
+          - **Package**: \`@bloqr/compiler-core\` (\`src/adblock-compiler-core/\`)
+
+          ### Changes
+          - Updated \`VERSION\` in \`src/adblock-compiler-core/src/version.ts\` (single source of truth)
+          - Synced \`version\` field in \`src/adblock-compiler-core/deno.json\` via \`deno task version:sync\`
+          - Updated \`CHANGELOG.md\`
+
+          ### Next steps
+          After this PR merges, a \`compiler-core-v${{ steps.bump.outputs.new }}\` tag is created automatically, and \`publish-jsr.yml\` publishes the new version to JSR.
+          EOF
+          )" \
+            --base main \
+            --head "$BRANCH_NAME"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # working-directory default above doesn't apply to `gh pr create`'s repo
+          # detection reliably across all runners, so be explicit:
+          GH_REPO: ${{ github.repository }}
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ "${{ steps.determine_bump.outputs.bump_type }}" = "none" ] || [ -z "${{ steps.determine_bump.outputs.bump_type }}" ]; then
+            echo "## ℹ️ No compiler-core version bump required" >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat <<EOF >> "$GITHUB_STEP_SUMMARY"
+          ## 🎉 compiler-core Version Bump PR Created
+          - **Old Version**: ${{ steps.bump.outputs.old }}
+          - **New Version**: ${{ steps.bump.outputs.new }}
+          - **Bump Type**: ${{ steps.determine_bump.outputs.bump_type }}
+          EOF
+          fi

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -7,6 +7,12 @@ name: Publish adblock-compiler-core to JSR
 #
 # AUTHENTICATION: Uses JSR_WORKFLOW_TOKEN (org-level Action secret, scoped to
 # @bloqr namespace). See docs/jsr-token-authentication.md for setup and usage.
+#
+# VERSIONING: deno.json's version is bumped automatically by
+# compiler-core-version-bump.yml (Conventional Commits) and tagged by
+# compiler-core-create-version-tag.yml on merge — this workflow doesn't bump
+# anything itself, it just publishes whatever version is currently checked
+# in. See docs/architecture/versioning-strategy.md for the full pattern.
 
 on:
   push:

--- a/docs/architecture/versioning-strategy.md
+++ b/docs/architecture/versioning-strategy.md
@@ -1,0 +1,79 @@
+# BloqrAI Versioning Strategy
+
+**Status**: Active standard, org-wide.
+**Scope**: Every independently-published `@bloqr` JSR package, in this repo and any future repo that publishes one.
+
+## The core rule
+
+**Code version and package version always match, and there is exactly one place you edit to change either.**
+
+Concretely, for any package that follows this standard:
+
+1. A `VERSION` constant in the package's own source (e.g. `src/version.ts`) is the single source of *writable* truth.
+2. A `version:sync` script propagates that constant into the package manifest (`deno.json`'s `"version"` field, and `package.json`/`wrangler.toml`/anything else that carries a duplicate copy, if the package has those).
+3. Nobody hand-edits `deno.json`'s version field directly — it's always derived.
+
+This isn't a new idea invented for this repo: `bloqr-compiler` (the private commercial monorepo) already runs exactly this pattern (`src/version.ts` → `scripts/sync-version.ts` → `deno.json`/`package.json`/`wrangler.toml`) and has for a while. This document makes it the explicit, written-down, org-wide standard — both because `bloqr-core` is about to need it for real (its first JSR package, `@bloqr/compiler-core`, just went live), and because `bloqr-core` is going to decompose into *several* independently-versioned JSR packages as that epic proceeds, which is a meaningfully different shape than `bloqr-compiler`'s single-package case.
+
+## Why "one repo, one version" doesn't work here
+
+`bloqr-compiler` has one deployable artifact, so one `VERSION` constant and one tag prefix (`v*` / `compiler-v*`) is sufficient. `bloqr-core` is different: it already contains multiple independent things (four rules-compiler implementations, a rules-validator, wrapper CLIs, a docs website), and the plan is to decompose the TypeScript/Deno side specifically into multiple standalone `@bloqr/*` JSR packages over time. Each of those needs to be versioned, tagged, and released **independently** — bumping `@bloqr/compiler-core` from 1.0.0 to 1.1.0 must not force (or even suggest) a version bump on some future `@bloqr/rules-schema` or `@bloqr/filter-utils` package that happens to live in the same repo and didn't change.
+
+So the standard is **per-package**, not per-repo:
+
+- Each package gets its own `VERSION` source-of-truth file, scoped to that package's own directory.
+- Each package gets its own git tag prefix: **`<package-slug>-v<semver>`** (e.g. `compiler-core-v1.2.3`). No bare `v*` tags in this repo once there's more than one package — bare `v*` is ambiguous the moment a second package exists.
+- Each package gets its own version-bump automation, scoped by path filter to only that package's directory, with its own bump-commit marker string (so `git log --grep` for "when did we last bump package X" doesn't accidentally match package Y's bump commits).
+- Each package's publish workflow triggers off changes to its own path (already true for `publish-jsr.yml` — see below) and/or its own tag.
+
+## Reference implementation: `@bloqr/compiler-core`
+
+This is the first package on the new standard, and it's meant to be the copy-paste template for every future one. Four pieces, all scoped to `src/adblock-compiler-core/`:
+
+| File | Role |
+|---|---|
+| `src/adblock-compiler-core/src/version.ts` | `export const VERSION = '1.0.0'` — hand-edited only by the bump automation (or a human doing a manual override), never by feature PRs. |
+| `src/adblock-compiler-core/scripts/sync-version.ts` | `deno task version:sync` — reads `VERSION` from `version.ts`, writes it into `deno.json`'s `"version"` field. No-ops if already in sync. |
+| `.github/workflows/compiler-core-version-bump.yml` | Runs on every push to `main` that touches `src/adblock-compiler-core/**`. Walks Conventional Commits since the last `chore: bump compiler-core version` commit, determines the bump type (see below), bumps `version.ts`, runs the sync script, updates `CHANGELOG.md`, and opens a PR (`auto-version-bump-compiler-core-<version>` branch). |
+| `.github/workflows/compiler-core-create-version-tag.yml` | Runs when a `auto-version-bump-compiler-core-*` PR merges. Reads the now-updated `deno.json` version and pushes the `compiler-core-v<version>` tag. |
+| `.github/workflows/publish-jsr.yml` | Unchanged by this doc's introduction — it already triggers on any push to `src/adblock-compiler-core/**` on `main`, and `deno publish` is idempotent (no-ops if the current version is already published). The version-bump PR's merge commit is what actually causes the next real publish; the tag above exists for traceability, not to gate the publish. |
+
+### Conventional Commits → bump type
+
+Same rule `bloqr-compiler` already uses, scoped to commits that touched the package's own directory:
+
+| Commit prefix | Bump |
+|---|---|
+| `fix:`, `perf:` | patch |
+| `feat:` | minor |
+| `feat!:`, `fix!:`, or a `BREAKING CHANGE:` footer | major |
+| anything else (`chore:`, `docs:`, `test:`, `ci:`, ...) | no bump |
+
+A push with no bump-worthy commits since the last bump is a silent no-op (logged to the workflow's job summary, no PR opened).
+
+## Onboarding a new decomposed package
+
+When a piece of `bloqr-core` (or a brand-new repo) becomes its own `@bloqr/*` JSR package, copy the compiler-core pattern with these substitutions:
+
+1. `<package-dir>/src/version.ts` (or equivalent) — new file, `VERSION = '0.1.0'` (or wherever the extracted code's version actually starts — if it's an extraction of existing code that already has a version, keep continuity rather than resetting to 0.1.0).
+2. `<package-dir>/scripts/sync-version.ts` — copy `compiler-core`'s, change the relative import path if the directory depth differs. If the new package also ships a `package.json`/`wrangler.toml` (unlikely for a pure JSR library, but possible), add sync steps for those too — see `bloqr-compiler`'s fuller `sync-version.ts` for that shape.
+3. `.github/workflows/<package-slug>-version-bump.yml` — copy `compiler-core-version-bump.yml`, replace:
+   - the `paths:` filter (`src/adblock-compiler-core/**` → the new package's path)
+   - the bump-commit grep marker (`chore: bump compiler-core version` → `chore: bump <package-slug> version`)
+   - the branch prefix (`auto-version-bump-compiler-core-` → `auto-version-bump-<package-slug>-`)
+   - the `working-directory` default
+4. `.github/workflows/<package-slug>-create-version-tag.yml` — copy `compiler-core-create-version-tag.yml`, same substitutions, tag prefix `<package-slug>-v`.
+5. That package's own `publish-jsr.yml` (or a shared one filtered by path — either is fine, `bloqr-core` currently has one workflow per publishable package) — path-filtered trigger, `deno publish --token ${{ secrets.JSR_WORKFLOW_TOKEN }}` per `docs/jsr-token-authentication.md`.
+6. Add the new package to `docs/jsr-org-standards.md`'s package table.
+
+## What this doc does *not* cover yet
+
+- The non-JSR wrapper projects in this repo (.NET, Python, Rust, PowerShell) have their own version fields (`.csproj`, `pyproject.toml`, `Cargo.toml`) and are not yet wired into an equivalent automated bump/tag/release pattern for their own registries (NuGet, PyPI, crates.io). `docs/release-guide.md` describes their current (manual, repo-wide-tag) release process, which predates this standard and still reflects the pre-split repo shape in places — it needs its own pass to either adopt an equivalent per-package pattern or explicitly document why it stays manual. Tracked as follow-up, not blocking this doc.
+- `rules-validator` (Rust) — same situation as above.
+- Cross-repo propagation: once packages are actually split out of `bloqr-core` into their own repos, this document (or a copy of it) needs to travel with them. For now, see `docs/org-documentation-strategy.md` for how org-wide docs are being tracked during this transitional period (`.github-private` for internal standards while things are still moving; this doc lives in `bloqr-core` itself since it's currently the one place with a working reference implementation).
+
+## Related
+
+- `docs/jsr-token-authentication.md` — how `publish-jsr.yml` authenticates to JSR.
+- `docs/jsr-org-standards.md` — JSR scope/package conventions this versioning strategy sits alongside.
+- `bloqr-compiler`'s `src/version.ts` / `scripts/sync-version.ts` / `.github/workflows/version-bump.yml` / `.github/workflows/create-version-tag.yml` — the pre-existing, independently-arrived-at prior art this standard formalizes and extends to the multi-package case.

--- a/docs/jsr-org-standards.md
+++ b/docs/jsr-org-standards.md
@@ -72,9 +72,13 @@ Publishing workflows should trigger on:
 ### Version Management
 
 - **Semantic Versioning**: All packages follow semver (MAJOR.MINOR.PATCH)
-- **Version Source**: `deno.json` or language-specific config (`Cargo.toml`, etc.)
+- **Version Source**: a per-package `VERSION` constant (e.g. `src/version.ts`) is the single source of truth, synced into `deno.json`'s `"version"` field by that package's `version:sync` task — never hand-edit `deno.json`'s version directly
+- **Automated bumps**: Conventional Commits (`feat:`/`fix:`/`perf:`/breaking) drive automatic version-bump PRs, one workflow pair per package, path-filtered to that package's directory
+- **Per-package tags**: `<package-slug>-v<semver>` (e.g. `compiler-core-v1.2.3`) — no bare `v*` tags once a repo has more than one JSR package
 - **Idempotent Publishing**: `deno publish` no-ops if version already exists
 - **Pre-release Versions**: Use `-rc`, `-beta`, `-alpha` suffixes for testing
+
+See **`docs/architecture/versioning-strategy.md`** for the full standard, the reference implementation (`@bloqr/compiler-core`), and the checklist for onboarding each future decomposed package onto the same pattern.
 
 ### Dry-Run Validation
 
@@ -114,9 +118,9 @@ For each BloqrAI repository, ensure:
 ## Future Improvements
 
 - **Provenance Attestations**: Investigate token-based provenance support with JSR
-- **Automated Versioning**: Consider semantic-release or changesets workflow
 - **Package Registry Mirror**: Mirror packages to npm for broader compatibility (future)
 - **API Token Rotation**: Automate token rotation via GitHub Actions
+- **Non-JSR wrapper versioning**: extend the `docs/architecture/versioning-strategy.md` pattern to the .NET/Python/Rust/PowerShell wrapper projects and their own registries (NuGet/PyPI/crates.io) — currently manual, see `docs/release-guide.md`
 
 ## Related Issues
 

--- a/src/adblock-compiler-core/deno.json
+++ b/src/adblock-compiler-core/deno.json
@@ -34,6 +34,7 @@
     "lint": "deno lint src/",
     "fmt": "deno fmt src/",
     "version": "deno run --allow-read --allow-env src/mod.ts --version",
+    "version:sync": "deno run --allow-read --allow-write scripts/sync-version.ts",
     "generate:types": "deno run --allow-read --allow-write --no-npm generate-types.ts"
   },
   "imports": {

--- a/src/adblock-compiler-core/scripts/sync-version.ts
+++ b/src/adblock-compiler-core/scripts/sync-version.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write
+
+/**
+ * Sync version from src/version.ts to deno.json.
+ *
+ * This script makes src/version.ts the single source of writable truth for
+ * @bloqr/compiler-core's version. Run it after updating the VERSION constant
+ * in src/version.ts to propagate the version into deno.json (the field JSR's
+ * publish step reads).
+ *
+ * Mirrors the equivalent script in bloqr-compiler (scripts/sync-version.ts) —
+ * see docs/architecture/versioning-strategy.md for the org-wide pattern this
+ * is part of.
+ *
+ * Usage:
+ *   deno task version:sync
+ *   deno run --allow-read --allow-write scripts/sync-version.ts
+ */
+
+import { VERSION } from '../src/version.ts';
+import { isValidSemver } from '../src/utils/semver.ts';
+
+function readVersionFromSource(): string {
+  if (!isValidSemver(VERSION)) {
+    throw new Error('VERSION has an invalid format in src/version.ts');
+  }
+  return VERSION;
+}
+
+/**
+ * Update the "version" field in deno.json.
+ */
+async function syncJsonFile(path: string, version: string): Promise<void> {
+  const content = await Deno.readTextFile(path);
+  const json = JSON.parse(content) as Record<string, unknown>;
+  const old = json['version'] as string | undefined;
+  if (old === version) {
+    console.log(`  ${path}: already at ${version}, skipping`);
+    return;
+  }
+  json['version'] = version;
+  await Deno.writeTextFile(path, JSON.stringify(json, null, 2) + '\n');
+  console.log(`  ${path}: ${old} → ${version}`);
+}
+
+async function main(): Promise<void> {
+  const version = readVersionFromSource();
+  console.log(`Syncing version ${version} from src/version.ts to:`);
+  await syncJsonFile('deno.json', version);
+  console.log('Done.');
+}
+
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
## Summary

Establishes BloqrAI's versioning strategy for `@bloqr` JSR packages, as requested: code versioning and package versioning always match (single source-of-truth `VERSION` constant, synced into `deno.json`), automated via Conventional Commits, and — crucially — **scoped per-package, not per-repo**, since `bloqr-core` is going to decompose into several independently-versioned JSR packages as the current epic proceeds.

## Why per-package, not per-repo

`bloqr-compiler` already runs this exact pattern (`src/version.ts` → `scripts/sync-version.ts` → `version-bump.yml` → `create-version-tag.yml`), and it works well there because it has one deployable artifact. `bloqr-core` is different: it already contains multiple independent things, and the plan is to split the TypeScript/Deno side into multiple standalone `@bloqr/*` JSR packages over time. Each needs independent versioning — bumping `@bloqr/compiler-core` must never imply or force a bump on some future sibling package in the same repo.

So this PR's automation is scoped by path filter to `src/adblock-compiler-core/**` specifically, with its own tag prefix (`compiler-core-v*`, not a bare `v*` that would become ambiguous the moment a second package exists), and `docs/architecture/versioning-strategy.md` documents the checklist for giving each future decomposed package its own copy of this same pattern.

## Changes

**Reference implementation for `@bloqr/compiler-core`** (`src/adblock-compiler-core/`):
- `src/version.ts` — already existed, remains the single source of truth (unchanged)
- `scripts/sync-version.ts` — **new**. `deno task version:sync` propagates `VERSION` into `deno.json`. No-ops if already in sync. Verified locally.
- `deno.json` — adds the `version:sync` task.
- `.github/workflows/compiler-core-version-bump.yml` — **new**. Runs on pushes to `main` touching `src/adblock-compiler-core/**`. Walks Conventional Commits since the last `chore: bump compiler-core version` commit, determines bump type (`feat:`→minor, `fix:`/`perf:`→patch, breaking→major), bumps `version.ts`, runs the sync script, updates `CHANGELOG.md`, opens a PR.
- `.github/workflows/compiler-core-create-version-tag.yml` — **new**. Tags `compiler-core-v<version>` when a version-bump PR merges.
- `.github/workflows/publish-jsr.yml` — unchanged behavior; added a comment connecting it to the new versioning workflows (it already triggers on push to `src/adblock-compiler-core/**`, and `deno publish` is idempotent, so the version-bump merge itself is what causes the next real publish — the tag exists for traceability, not to gate anything).

**Documentation**:
- `docs/architecture/versioning-strategy.md` — **new**. The full standard: single-source-of-truth rule, why per-repo doesn't work here, the reference implementation walkthrough, and the onboarding checklist for future packages.
- `docs/jsr-org-standards.md` — updated Version Management section to link to the new doc, moved "Automated Versioning" out of Future Improvements (it's now done) and added non-JSR-wrapper versioning as a genuinely future item.

## Verification

- `deno check scripts/sync-version.ts` — clean
- `deno task check` (main entrypoint) — clean
- `deno lint scripts/sync-version.ts` — clean
- `deno task version:sync` — confirmed no-ops correctly when already in sync
- `deno publish --dry-run` — passes
- Both new workflow YAML files validated with a YAML parser

## Explicitly out of scope for this PR

- `docs/release-guide.md` still describes the old repo-wide manual tag process and references `AdGuard.ConsoleUI` (removed in the API-client migration). It's also on issue #289's file list for stale-path cleanup — left alone here to avoid a guaranteed conflict with that PR. Needs a follow-up pass once #289 lands to reflect the new per-package tag scheme.
- Non-JSR wrapper projects (.NET/Python/Rust/PowerShell) and `rules-validator` don't get an equivalent automated pattern in this PR — flagged as future work in the new doc.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Njq8s2j9cXsSBoYMjocwHN)_