### PR TITLE
docs(compiler-core): add module docs and fill JSDoc gaps for JSR score

### DIFF
--- a/src/adblock-compiler-core/src/configuration/schemas.ts
+++ b/src/adblock-compiler-core/src/configuration/schemas.ts
@@ -24,6 +24,7 @@ export const PrioritySchema: z.ZodEnum<{ standard: 'standard'; high: 'high' }> =
   'standard',
   'high',
 ]).describe('Request processing priority level');
+/** Inferred TypeScript type for {@linkcode PrioritySchema}: `'standard' | 'high'`. */
 export type Priority = z.infer<typeof PrioritySchema>;
 
 // ============================================================================
@@ -403,6 +404,10 @@ type BenchmarkMetricsOutput = {
   outputRuleCount: number;
 };
 
+/**
+ * Compilation result returned by worker/queue-based compilation, extending the base result
+ * with optional {@linkcode BenchmarkMetricsOutput} when benchmark mode was requested.
+ */
 export type WorkerCompilationResultOutput = CompilationResultBaseOutput & {
   metrics?: BenchmarkMetricsOutput;
 };
@@ -485,6 +490,7 @@ const compilationResultBase: z.ZodObject<{
  */
 export const CompilationResultSchema: z.ZodType<CompilationResultBaseOutput> =
   compilationResultBase;
+/** Inferred TypeScript type for {@linkcode CompilationResultSchema}: the compiled rules plus a count. */
 export type CompilationResultOutput = CompilationResultBaseOutput;
 
 /**
@@ -509,6 +515,7 @@ export const BenchmarkMetricsSchema: z.ZodType<BenchmarkMetricsOutput> = z.objec
   ruleCount: z.number().int().nonnegative().describe('Total number of input rules'),
   outputRuleCount: z.number().int().nonnegative().describe('Number of rules in the final output'),
 });
+/** Inferred TypeScript type for {@linkcode BenchmarkMetricsSchema}: per-stage compilation timing data. */
 export type BenchmarkMetrics = BenchmarkMetricsOutput;
 
 /**
@@ -607,6 +614,7 @@ export const CliArgumentsSchema: z.ZodType<CliArgumentsOutput> = z.object({
     path: ['apiKey'],
   },
 );
+/** Inferred TypeScript type for {@linkcode CliArgumentsSchema}: the parsed CLI argument set. */
 export type CliArguments = CliArgumentsOutput;
 
 /**
@@ -626,6 +634,7 @@ export const EnvironmentSchema: z.ZodType<EnvironmentOutput> = z.object({
     'Minimum log level to emit',
   ),
 }).passthrough(); // Allow additional worker bindings
+/** Inferred TypeScript type for {@linkcode EnvironmentSchema}: worker/runtime environment bindings. */
 export type Environment = EnvironmentOutput;
 
 // ============================================================================
@@ -645,6 +654,7 @@ export const AdblockRuleSchema: z.ZodType<AdblockRuleOutput> = z.object({
   })).nullable(),
   hostname: z.string().nullable(),
 });
+/** Inferred TypeScript type for {@linkcode AdblockRuleSchema}: a parsed adblock-syntax rule. */
 export type AdblockRule = AdblockRuleOutput;
 
 /**
@@ -654,4 +664,5 @@ export const EtcHostsRuleSchema: z.ZodType<EtcHostsRuleOutput> = z.object({
   ruleText: z.string().min(1),
   hostnames: z.array(z.string()).nonempty(),
 });
+/** Inferred TypeScript type for {@linkcode EtcHostsRuleSchema}: a parsed `/etc/hosts`-syntax rule. */
 export type EtcHostsRule = EtcHostsRuleOutput;

--- a/src/adblock-compiler-core/src/console/app.ts
+++ b/src/adblock-compiler-core/src/console/app.ts
@@ -82,6 +82,10 @@ export class ConsoleApplication {
   private readonly options: ConsoleAppOptions;
   private configPath?: string;
 
+  /**
+   * Creates a new `ConsoleApplication`.
+   * @param options Initial configuration path, format override, and debug logging flag.
+   */
   constructor(options: ConsoleAppOptions = {}) {
     this.options = options;
     this.configPath = options.configPath;

--- a/src/adblock-compiler-core/src/console/index.ts
+++ b/src/adblock-compiler-core/src/console/index.ts
@@ -1,6 +1,22 @@
 /**
- * Console module exports
- * Interactive mode components for the Rules Compiler
+ * Interactive console UI components for the Rules Compiler.
+ *
+ * Provides the terminal-styling primitives (colored output, tables,
+ * spinners, banners) and the {@linkcode ConsoleApplication} menu-driven
+ * interface used by the orchestration layer's interactive mode. Import
+ * this module directly (via the package's `console` export subpath) to
+ * build custom terminal UIs, or use `runInteractive` for the ready-made
+ * menu experience.
+ *
+ * @example
+ * ```ts
+ * import { runInteractive } from '@bloqr/compiler-core/console';
+ *
+ * const exitCode = await runInteractive({ configPath: 'compiler-config.yaml' });
+ * ```
+ *
+ * @module console
+ * @packageDocumentation
  */
 
 // Utilities

--- a/src/adblock-compiler-core/src/formatters/OutputFormatter.ts
+++ b/src/adblock-compiler-core/src/formatters/OutputFormatter.ts
@@ -206,8 +206,10 @@ export abstract class HostnameListFormatter extends BaseFormatter {
  * Formats rules to /etc/hosts format
  */
 export class HostsFormatter extends HostnameListFormatter {
+  /** Always `OutputFormat.Hosts`. */
   protected override readonly outputFormat: OutputFormat = OutputFormat.Hosts;
 
+  /** Prepends `localhost` entries when `options.includeLocalhost` is set. */
   protected override preambleLines(): string[] {
     // Add localhost entries if requested
     if (this.options.includeLocalhost) {
@@ -216,6 +218,11 @@ export class HostsFormatter extends HostnameListFormatter {
     return [];
   }
 
+  /**
+   * Formats a hostname as an `/etc/hosts` line.
+   * @param hostname The hostname to format.
+   * @returns `"<hostsIp> <hostname>"`, using `options.hostsIp` (default `0.0.0.0`).
+   */
   protected override formatHostnameLine(hostname: string): string {
     return `${this.options.hostsIp} ${hostname}`;
   }
@@ -225,8 +232,14 @@ export class HostsFormatter extends HostnameListFormatter {
  * Formats rules to dnsmasq format
  */
 export class DnsmasqFormatter extends HostnameListFormatter {
+  /** Always `OutputFormat.Dnsmasq`. */
   protected override readonly outputFormat: OutputFormat = OutputFormat.Dnsmasq;
 
+  /**
+   * Formats a hostname as a dnsmasq `address=` directive.
+   * @param hostname The hostname to format.
+   * @returns `"address=/<hostname>/"`.
+   */
   protected override formatHostnameLine(hostname: string): string {
     return `address=/${hostname}/`;
   }
@@ -236,8 +249,14 @@ export class DnsmasqFormatter extends HostnameListFormatter {
  * Formats rules to Pi-hole format (domain list)
  */
 export class PiHoleFormatter extends HostnameListFormatter {
+  /** Always `OutputFormat.PiHole`. */
   protected override readonly outputFormat: OutputFormat = OutputFormat.PiHole;
 
+  /**
+   * Formats a hostname as a bare domain-list line.
+   * @param hostname The hostname to format.
+   * @returns `hostname`, unchanged.
+   */
   protected override formatHostnameLine(hostname: string): string {
     return hostname;
   }
@@ -247,12 +266,19 @@ export class PiHoleFormatter extends HostnameListFormatter {
  * Formats rules to Unbound DNS resolver format
  */
 export class UnboundFormatter extends HostnameListFormatter {
+  /** Always `OutputFormat.Unbound`. */
   protected override readonly outputFormat: OutputFormat = OutputFormat.Unbound;
 
+  /** Emits the `server:` block header Unbound requires before `local-zone` directives. */
   protected override preambleLines(): string[] {
     return ['server:'];
   }
 
+  /**
+   * Formats a hostname as an Unbound `local-zone` directive.
+   * @param hostname The hostname to format.
+   * @returns `'    local-zone: "<hostname>" always_nxdomain'`.
+   */
   protected override formatHostnameLine(hostname: string): string {
     return `    local-zone: "${hostname}" always_nxdomain`;
   }
@@ -316,13 +342,20 @@ export class JsonFormatter extends BaseFormatter {
  * Formats rules to DNS-over-HTTPS blocklist format
  */
 export class DoHFormatter extends HostnameListFormatter {
+  /** Always `OutputFormat.DoH`. */
   protected override readonly outputFormat: OutputFormat = OutputFormat.DoH;
 
+  /** Always `false` — DoH blocklists are plain domain lists with no comment header. */
   protected override shouldIncludeHeader(): boolean {
     // DoH blocklists are plain domain lists with no comment lines
     return false;
   }
 
+  /**
+   * Formats a hostname as a bare domain-list line.
+   * @param hostname The hostname to format.
+   * @returns `hostname`, unchanged.
+   */
   protected override formatHostnameLine(hostname: string): string {
     return hostname;
   }

--- a/src/adblock-compiler-core/src/lib/index.ts
+++ b/src/adblock-compiler-core/src/lib/index.ts
@@ -32,6 +32,7 @@
  * const rules = await compiler.compileFromConfig(config);
  * ```
  *
+ * @module lib
  * @packageDocumentation
  */
 

--- a/src/adblock-compiler-core/src/orchestration/cli.ts
+++ b/src/adblock-compiler-core/src/orchestration/cli.ts
@@ -1,9 +1,21 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-run
 /**
- * Command-line interface for the Rules Compiler TypeScript Frontend
- * Production-ready with graceful shutdown and structured error handling
- * Supports both interactive and command-line modes
- * Deno-only implementation
+ * Command-line interface for the Rules Compiler TypeScript frontend.
+ *
+ * Production-ready with graceful shutdown and structured error handling.
+ * Supports both interactive menu mode and non-interactive command-line
+ * mode (argument parsing, help/version output, and the {@linkcode main}
+ * entry point used by the `cli` export subpath). Deno-only implementation.
+ *
+ * @example Parse arguments and run the CLI
+ * ```ts
+ * import { main } from '@bloqr/compiler-core/cli';
+ *
+ * const exitCode = await main(['--config', 'compiler-config.yaml']);
+ * ```
+ *
+ * @module cli
+ * @packageDocumentation
  */
 
 import { resolve } from 'node:path';

--- a/src/adblock-compiler-core/src/orchestration/errors.ts
+++ b/src/adblock-compiler-core/src/orchestration/errors.ts
@@ -67,13 +67,27 @@ export interface ErrorContext {
  * Base error class for all compiler errors
  */
 export class CompilerError extends Error {
+  /** Machine-readable code identifying the specific failure (see {@linkcode ErrorCode}). */
   public readonly code: ErrorCode;
+  /** How serious the error is — whether the operation can continue, failed, or must abort. */
   public readonly severity: ErrorSeverity;
+  /** Structured metadata about the failure (file path, URL, config name, etc.). */
   public readonly context: ErrorContext;
+  /** When this error was constructed. */
   public readonly timestamp: Date;
+  /** The underlying error that triggered this one, if any. */
   public override readonly cause?: Error;
+  /** The error's class name, used for logging and `instanceof`-free discrimination. */
   public override name: string;
 
+  /**
+   * Creates a new `CompilerError`.
+   * @param message Human-readable description of the failure.
+   * @param code Machine-readable {@linkcode ErrorCode} for the failure.
+   * @param severity How serious the error is. Defaults to `ErrorSeverity.ERROR`.
+   * @param context Structured metadata to attach for debugging/logging.
+   * @param cause The underlying error that triggered this one, if any.
+   */
   constructor(
     message: string,
     code: ErrorCode,
@@ -126,6 +140,13 @@ export class CompilerError extends Error {
  * Configuration-related errors
  */
 export class ConfigurationError extends CompilerError {
+  /**
+   * Creates a new `ConfigurationError`.
+   * @param message Human-readable description of the failure.
+   * @param code Machine-readable {@linkcode ErrorCode}. Defaults to `CONFIG_VALIDATION_ERROR`.
+   * @param context Structured metadata to attach for debugging/logging.
+   * @param cause The underlying error that triggered this one, if any.
+   */
   constructor(
     message: string,
     code: ErrorCode = ErrorCode.CONFIG_VALIDATION_ERROR,
@@ -141,6 +162,11 @@ export class ConfigurationError extends CompilerError {
  * Configuration not found error
  */
 export class ConfigNotFoundError extends ConfigurationError {
+  /**
+   * Creates a new `ConfigNotFoundError`.
+   * @param filePath Path to the configuration file that could not be found.
+   * @param cause The underlying filesystem error, if any.
+   */
   constructor(filePath: string, cause?: Error) {
     super(
       `Configuration file not found: ${filePath}`,
@@ -156,6 +182,13 @@ export class ConfigNotFoundError extends ConfigurationError {
  * Configuration parse error
  */
 export class ConfigParseError extends ConfigurationError {
+  /**
+   * Creates a new `ConfigParseError`.
+   * @param filePath Path to the configuration file that failed to parse.
+   * @param format The configuration format being parsed (e.g. `'yaml'`, `'toml'`, `'json'`).
+   * @param parseError The underlying parser's error message.
+   * @param cause The underlying parse error, if any.
+   */
   constructor(filePath: string, format: string, parseError: string, cause?: Error) {
     super(
       `Failed to parse ${format.toUpperCase()} configuration: ${parseError}`,
@@ -171,6 +204,13 @@ export class ConfigParseError extends ConfigurationError {
  * Compilation-related errors
  */
 export class CompilationError extends CompilerError {
+  /**
+   * Creates a new `CompilationError`.
+   * @param message Human-readable description of the failure.
+   * @param code Machine-readable {@linkcode ErrorCode}. Defaults to `COMPILATION_FAILED`.
+   * @param context Structured metadata to attach for debugging/logging.
+   * @param cause The underlying error that triggered this one, if any.
+   */
   constructor(
     message: string,
     code: ErrorCode = ErrorCode.COMPILATION_FAILED,
@@ -186,8 +226,14 @@ export class CompilationError extends CompilerError {
  * Compilation timeout error
  */
 export class CompilationTimeoutError extends CompilationError {
+  /** The timeout, in milliseconds, that was exceeded. */
   public readonly timeoutMs: number;
 
+  /**
+   * Creates a new `CompilationTimeoutError`.
+   * @param timeoutMs The timeout, in milliseconds, that was exceeded.
+   * @param context Structured metadata to attach for debugging/logging.
+   */
   constructor(timeoutMs: number, context: ErrorContext = {}) {
     super(
       `Compilation timed out after ${timeoutMs}ms`,
@@ -203,6 +249,13 @@ export class CompilationTimeoutError extends CompilationError {
  * File system errors
  */
 export class FileSystemError extends CompilerError {
+  /**
+   * Creates a new `FileSystemError`.
+   * @param message Human-readable description of the failure.
+   * @param code Machine-readable {@linkcode ErrorCode}. Defaults to `FILE_READ_ERROR`.
+   * @param context Structured metadata to attach for debugging/logging.
+   * @param cause The underlying filesystem error, if any.
+   */
   constructor(
     message: string,
     code: ErrorCode = ErrorCode.FILE_READ_ERROR,
@@ -218,6 +271,10 @@ export class FileSystemError extends CompilerError {
  * Path traversal security error
  */
 export class PathTraversalError extends CompilerError {
+  /**
+   * Creates a new `PathTraversalError`.
+   * @param path The path in which a directory-traversal attempt (e.g. `../`) was detected.
+   */
   constructor(path: string) {
     super(
       `Path traversal detected in path: ${path}`,
@@ -233,6 +290,13 @@ export class PathTraversalError extends CompilerError {
  * Input validation errors
  */
 export class ValidationError extends CompilerError {
+  /**
+   * Creates a new `ValidationError`.
+   * @param message Human-readable description of the failure.
+   * @param code Machine-readable {@linkcode ErrorCode}. Defaults to `INVALID_ARGUMENT`.
+   * @param context Structured metadata to attach for debugging/logging.
+   * @param cause The underlying error that triggered this one, if any.
+   */
   constructor(
     message: string,
     code: ErrorCode = ErrorCode.INVALID_ARGUMENT,
@@ -248,8 +312,13 @@ export class ValidationError extends CompilerError {
  * Shutdown requested error (for graceful shutdown)
  */
 export class ShutdownError extends CompilerError {
+  /** The OS signal (e.g. `'SIGTERM'`, `'SIGINT'`) that triggered the shutdown. */
   public readonly signal: string;
 
+  /**
+   * Creates a new `ShutdownError`.
+   * @param signal The OS signal that triggered the shutdown.
+   */
   constructor(signal: string) {
     super(
       `Shutdown requested via ${signal}`,
@@ -266,10 +335,19 @@ export class ShutdownError extends CompilerError {
  * Resource limit exceeded error
  */
 export class ResourceLimitError extends CompilerError {
+  /** The configured maximum allowed for `resource`. */
   public readonly limit: number;
+  /** The actual value that exceeded `limit`. */
   public readonly actual: number;
+  /** Name of the resource whose limit was exceeded (e.g. `'configFileSize'`, `'sourceCount'`). */
   public readonly resource: string;
 
+  /**
+   * Creates a new `ResourceLimitError`.
+   * @param resource Name of the resource whose limit was exceeded.
+   * @param limit The configured maximum allowed for `resource`.
+   * @param actual The actual value that exceeded `limit`.
+   */
   constructor(resource: string, limit: number, actual: number) {
     super(
       `Resource limit exceeded for ${resource}: ${actual} > ${limit}`,

--- a/src/adblock-compiler-core/src/orchestration/index.ts
+++ b/src/adblock-compiler-core/src/orchestration/index.ts
@@ -11,6 +11,7 @@
  * package's `orchestration` export subpath) for the CLI-wrapper API.
  * Import the package root for the bare compilation engine.
  *
+ * @module orchestration
  * @packageDocumentation
  */
 

--- a/src/adblock-compiler-core/src/orchestration/shutdown.ts
+++ b/src/adblock-compiler-core/src/orchestration/shutdown.ts
@@ -45,6 +45,12 @@ export class ShutdownHandler {
   private readonly logger?: Logger;
   private signalHandlers: Map<DenoSignal, () => void> = new Map();
 
+  /**
+   * Creates a new `ShutdownHandler`. Does not itself register signal listeners; call
+   * {@linkcode listen} to start watching for `SIGTERM`/`SIGINT`.
+   * @param config Partial shutdown configuration, merged over the defaults
+   * (10s cleanup timeout, no logger).
+   */
   constructor(config: Partial<ShutdownConfig> = {}) {
     this.config = { ...DEFAULT_SHUTDOWN_CONFIG, ...config };
     this.logger = config.logger;

--- a/src/adblock-compiler-core/src/orchestration/types.ts
+++ b/src/adblock-compiler-core/src/orchestration/types.ts
@@ -185,9 +185,13 @@ export interface ExtendedConfiguration extends IConfiguration {
  * Logger interface for consistent logging
  */
 export interface Logger {
+  /** Logs an informational message. */
   info(message: string, ...args: unknown[]): void;
+  /** Logs a warning that does not stop execution. */
   warn(message: string, ...args: unknown[]): void;
+  /** Logs an error, typically alongside a failure or caught exception. */
   error(message: string, ...args: unknown[]): void;
+  /** Logs a diagnostic message intended for troubleshooting, not shown by default. */
   debug(message: string, ...args: unknown[]): void;
 }
 

--- a/src/adblock-compiler-core/src/orchestration/validation.ts
+++ b/src/adblock-compiler-core/src/orchestration/validation.ts
@@ -17,8 +17,11 @@ import {
  * Validation result
  */
 export interface ValidationResult {
+  /** `true` if the configuration passed validation (no errors, though there may be warnings). */
   valid: boolean;
+  /** Fatal validation problems that must be fixed before the configuration can be used. */
   errors: string[];
+  /** Non-fatal issues worth surfacing to the user but that do not block compilation. */
   warnings: string[];
 }
 

--- a/src/adblock-compiler-core/src/transformations/TransformationHooks.ts
+++ b/src/adblock-compiler-core/src/transformations/TransformationHooks.ts
@@ -394,10 +394,12 @@ export class TransformationHookManager {
  * - `new FilterCompiler(logger)` (legacy constructor path)
  */
 export class NoOpHookManager extends TransformationHookManager {
+  /** Does nothing; overridden to keep the "before" hook path allocation-free. */
   override async executeBeforeHooks(_context: TransformationHookContext): Promise<void> {
     // No-op
   }
 
+  /** Does nothing; overridden to keep the "after" hook path allocation-free. */
   override async executeAfterHooks(
     _context: TransformationHookContext & {
       inputCount: number;
@@ -408,12 +410,14 @@ export class NoOpHookManager extends TransformationHookManager {
     // No-op
   }
 
+  /** Does nothing; overridden to keep the "error" hook path allocation-free. */
   override async executeErrorHooks(
     _context: TransformationHookContext & { error: Error },
   ): Promise<void> {
     // No-op
   }
 
+  /** Always returns `false`, so callers can skip hook dispatch entirely. */
   override hasHooks(): boolean {
     return false;
   }

--- a/src/adblock-compiler-core/src/transformations/ValidateTransformation.ts
+++ b/src/adblock-compiler-core/src/transformations/ValidateTransformation.ts
@@ -57,6 +57,12 @@ export class ValidateTransformation extends SyncTransformation {
 
   private currentSourceName?: string;
 
+  /**
+   * Creates a new `ValidateTransformation`.
+   * @param allowIp When `true`, rules targeting bare IP addresses are treated as valid
+   * (used by the `ValidateAllowIp` variant); when `false`, they are rejected.
+   * @param logger Optional logger used to report validation warnings/errors.
+   */
   constructor(allowIp = false, logger?: ILogger) {
     super(logger);
     this.allowIp = allowIp;
@@ -347,16 +353,27 @@ export class ValidateTransformation extends SyncTransformation {
  * Convenience transformation that validates rules while allowing raw IP addresses.
  */
 export class ValidateAllowIpTransformation extends SyncTransformation {
+  /** Always `TransformationType.ValidateAllowIp`. */
   public readonly type: TransformationType = TransformationType.ValidateAllowIp;
+  /** Always `'ValidateAllowIp'`. */
   public readonly name = 'ValidateAllowIp';
 
   private readonly validator: ValidateTransformation;
 
+  /**
+   * Creates a new `ValidateAllowIpTransformation`.
+   * @param logger Optional logger used to report validation warnings/errors.
+   */
   constructor(logger?: ILogger) {
     super(logger);
     this.validator = new ValidateTransformation(true, logger);
   }
 
+  /**
+   * Validates the given rules, removing invalid ones while allowing bare-IP hostnames.
+   * @param rules Rules to validate.
+   * @returns The subset of `rules` that passed validation.
+   */
   public executeSync(rules: readonly string[]): readonly string[] {
     return this.validator.executeSync(rules);
   }

--- a/src/adblock-compiler-core/src/utils/CircuitBreaker.ts
+++ b/src/adblock-compiler-core/src/utils/CircuitBreaker.ts
@@ -71,8 +71,15 @@ export interface CircuitBreakerStats {
  * Circuit breaker error thrown when the circuit is open
  */
 export class CircuitBreakerOpenError extends Error {
+  /** Always `'CircuitBreakerOpenError'`; useful for `instanceof`-free error discrimination. */
   public override readonly name: string = 'CircuitBreakerOpenError';
 
+  /**
+   * Creates a new `CircuitBreakerOpenError`.
+   * @param message Human-readable description of why the request was rejected.
+   * @param state The circuit breaker's state at the time the error was thrown (typically `OPEN`).
+   * @param breakerName Optional identifier of the circuit breaker, prepended to the message.
+   */
   constructor(
     message: string,
     public readonly state: CircuitBreakerState,

--- a/src/adblock-compiler-core/src/utils/logger.ts
+++ b/src/adblock-compiler-core/src/utils/logger.ts
@@ -35,6 +35,7 @@ const Colors = {
  * Module-specific log level overrides
  */
 export interface ModuleOverrides {
+  /** Maps a module name to the {@linkcode LogLevel} that should apply to loggers created for it. */
   [moduleName: string]: LogLevel;
 }
 
@@ -42,9 +43,13 @@ export interface ModuleOverrides {
  * Logger configuration options
  */
 export interface LoggerOptions {
+  /** Minimum level to emit; messages below this level are suppressed. Defaults to `LogLevel.Info`. */
   level?: LogLevel;
+  /** String prepended to every log line, before the timestamp/level tags. */
   prefix?: string;
+  /** Whether to prefix each log line with an ISO-8601 timestamp. Defaults to `false`. */
   timestamps?: boolean;
+  /** Whether to colorize output with ANSI escape codes. Defaults to `true`. */
   colors?: boolean;
   /** Enable structured JSON output for production observability */
   structured?: boolean;
@@ -69,13 +74,24 @@ function getTimestamp(): string {
  * Console-based logger implementation for Deno
  */
 export class Logger implements ILogger {
+  /** The effective minimum level for this logger instance, after resolving module overrides. */
   protected level: LogLevel;
+  /** String prepended to every log line emitted by this instance. */
   protected prefix: string;
+  /** Whether ISO-8601 timestamps are prefixed to log lines. */
   protected timestamps: boolean;
+  /** Whether ANSI color codes are applied to log output. */
   protected colors: boolean;
+  /** Module name this logger instance was created for, used to resolve {@linkcode moduleOverrides}. */
   protected module: string;
+  /** Per-module {@linkcode LogLevel} overrides applied when resolving this logger's effective level. */
   protected moduleOverrides: ModuleOverrides;
 
+  /**
+   * Creates a new `Logger`.
+   * @param options Logger configuration; unset fields fall back to sensible defaults
+   * (`LogLevel.Info`, no prefix, no timestamps, colors enabled).
+   */
   constructor(options: LoggerOptions = {}) {
     this.module = options.module ?? '';
     this.moduleOverrides = options.moduleOverrides ?? {};
@@ -418,6 +434,11 @@ export class StructuredLogger extends Logger {
   private correlationId?: string;
   private traceId?: string;
 
+  /**
+   * Creates a new `StructuredLogger`.
+   * @param options Logger configuration. `correlationId` and `traceId` are attached to every
+   * emitted JSON record; all other options behave as in {@linkcode Logger}.
+   */
   constructor(options: LoggerOptions = {}) {
     // Pass non-structured options to parent
     super({

--- a/src/adblock-compiler-core/src/version.ts
+++ b/src/adblock-compiler-core/src/version.ts
@@ -1,10 +1,16 @@
 /**
  * Package identity constants for @bloqr/compiler-core.
  */
+/** The published version of this package, kept in sync with `deno.json`. */
 export const VERSION = '1.0.0';
+
+/** The fully-scoped JSR package name, e.g. for use in User-Agent strings or log output. */
 export const PACKAGE_NAME = '@bloqr/compiler-core';
+
+/** A `name/version` User-Agent string identifying this package, suitable for HTTP requests. */
 export const USER_AGENT = `${PACKAGE_NAME}/${VERSION}`;
 
+/** Convenience bundle of {@linkcode PACKAGE_NAME}, {@linkcode VERSION}, and {@linkcode USER_AGENT}. */
 export const PACKAGE_INFO = {
   name: PACKAGE_NAME,
   version: VERSION,


### PR DESCRIPTION
## Summary

Closes #293. Improves the two documentation-related JSR score gaps for `@bloqr/compiler-core`:

1. **Module documentation (was 0/1).** Added a `@module` JSDoc tag to the four entrypoints that had a top-of-file doc comment but no `@module` tag (per [JSR's module documentation spec](https://jsr.io/docs/writing-docs#module-documentation), the tag is what JSR recognizes). `src/index.ts` already had one.
   - `./lib` → `src/lib/index.ts`
   - `./orchestration` → `src/orchestration/index.ts`
   - `./console` → `src/console/index.ts` (previously had no doc comment at all — added a full one with an example)
   - `./cli` → `src/orchestration/cli.ts`
2. **Symbol documentation (was 82%).** Added JSDoc (with `@param`/`@returns` where applicable) to every exported symbol `deno doc --lint` flagged as undocumented across all 5 entrypoints — error classes and their fields/constructors in `orchestration/errors.ts`, formatter subclass overrides in `formatters/OutputFormatter.ts`, `Logger`/`StructuredLogger` fields and constructors, schema type aliases in `configuration/schemas.ts`, transformation hook/validate classes, `CircuitBreakerOpenError`, `version.ts` constants, and a handful of small interfaces (`ValidationResult`, `Logger`, `ConsoleAppOptions` consumers, etc.).

No import statements, dependency choices, or runtime behavior were touched — this is a pure documentation-content change.

## Before / after: `deno doc --lint`

Ran against each of the 5 published entrypoints (`src/index.ts`, `src/lib/index.ts`, `src/orchestration/index.ts`, `src/console/index.ts`, `src/orchestration/cli.ts`):

| Entrypoint | `missing-jsdoc` before | `missing-jsdoc` after |
|---|---|---|
| `.` | 48 | **0** |
| `./lib` | 7 | **0** |
| `./orchestration` | 31 | **0** |
| `./console` | 1 | **0** |
| `./cli` | 0 | **0** |

All 5 entrypoints are now free of `missing-jsdoc` findings, and all 5 now carry an `@module` tag (module docs 0/1 → complete).

### `private-type-ref` — investigated, left out of scope

`deno doc --lint` also reports `private-type-ref` findings (a public function/schema's signature referencing an internal, un-exported type — e.g. `Ora`/`ChalkInstance` from the `ora`/`chalk` npm packages, or internal helper types like `IConfiguration`'s siblings in `schemas.ts`). These are **unchanged by this PR** (28/7/19/9/2 per entrypoint, same before and after), and I'm intentionally not touching them here:

- They're a distinct JSR score category ("slow types" / fast-check), not the "module docs" or "symbol docs" gaps this issue asks for. I confirmed via `https://api.jsr.io/scopes/bloqr/packages/compiler-core/score` that the currently-published `1.0.0` already has `"allFastCheck": true` — this category is already passing and unaffected by these findings.
- `deno publish --dry-run` (which runs JSR's actual "Checking for slow types in the public API..." pass) completes with **no errors or warnings** on this branch, confirming the same.
- Actually resolving them would mean promoting ~25+ currently-internal implementation types to the public API surface (or restructuring formatter/console helpers to not leak `chalk`/`cli-table3`/`ora` types), which is an API-surface design decision well beyond "add documentation" and risks colliding with the parallel dependency-sourcing work on #294 touching the same files. Flagging for a possible separate follow-up issue if the team wants those cleaned up too.

## Verification (local proxy for JSR's scoring pipeline)

All run from `src/adblock-compiler-core/`:
- `deno task check` — pass
- `deno task lint` — pass (146 files)
- `deno task test` — pass (1008 passed, 0 failed, 6 ignored)
- `deno publish --dry-run` — pass, "Dry run complete", no slow-types warnings

## Note on scope / overlap with #294

Per the task guardrails, this touches several of the same files as the in-flight dependency-sourcing work for #294 (npm→JSR-native swaps for `yaml`/`toml`/`chalk`/`cli-table3`/`ora`). This PR only adds JSDoc comments — no import or dependency changes — but a merge conflict when reconciling both PRs is expected and can be resolved separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Njq8s2j9cXsSBoYMjocwHN)_