### PR TITLE
fix: make sync-version.ts JSONC-safe

### DIFF
--- a/src/adblock-compiler-core/scripts/sync-version.ts
+++ b/src/adblock-compiler-core/scripts/sync-version.ts
@@ -28,18 +28,30 @@ function readVersionFromSource(): string {
 }
 
 /**
- * Update the "version" field in deno.json.
+ * Update the "version" field in deno.json via a surgical regex replace,
+ * rather than a JSON.parse/stringify round-trip. deno.json supports JSONC
+ * (`//` comments) — e.g. the accepted-npm-exception notes next to `ora`,
+ * `figlet`, and `@inquirer/prompts` in the `imports` block — and Deno's own
+ * config loader tolerates that, but a plain JSON.parse/stringify round-trip
+ * would both reject the comments as invalid JSON and silently drop them on
+ * write. Regex-replacing just the version line preserves everything else
+ * byte-for-byte, matching the same approach bloqr-compiler's sync-version.ts
+ * uses for wrangler.toml's COMMENT_VERSION field.
  */
 async function syncJsonFile(path: string, version: string): Promise<void> {
   const content = await Deno.readTextFile(path);
-  const json = JSON.parse(content) as Record<string, unknown>;
-  const old = json['version'] as string | undefined;
+  const versionLineRegex = /^(\s*"version"\s*:\s*")([^"]*)(")/m;
+  const match = content.match(versionLineRegex);
+  if (!match) {
+    throw new Error(`Could not find a "version" field in ${path}`);
+  }
+  const old = match[2];
   if (old === version) {
     console.log(`  ${path}: already at ${version}, skipping`);
     return;
   }
-  json['version'] = version;
-  await Deno.writeTextFile(path, JSON.stringify(json, null, 2) + '\n');
+  const updated = content.replace(versionLineRegex, `$1${version}$3`);
+  await Deno.writeTextFile(path, updated);
   console.log(`  ${path}: ${old} → ${version}`);
 }
 


### PR DESCRIPTION
## Summary

Bug caught in a final verification pass after merging #295, #296, #297, and #298: `deno task version:sync` throws a `SyntaxError` on the current `main`.

## Root cause

`deno.json` legitimately contains `//` comments — the accepted-npm-exception notes next to `ora`, `figlet`, and `@inquirer/prompts` added in #298, explaining why those stay on npm. Deno's own config loader tolerates JSONC (comments in `deno.json`), which is why `deno task check`/`lint`/`test` and `deno publish --dry-run` all passed fine in every individual PR's verification. But `scripts/sync-version.ts` (added in #295) used `JSON.parse()`/`JSON.stringify()`, which doesn't support comments — it would throw on read, and even if it didn't, a full parse/stringify round-trip would silently delete all the comments on write.

This gap existed because #295 never ran against #298's deno.json content (they were separate PRs merged sequentially), and neither PR's own verification happened to call `version:sync` after both were combined.

## Fix

Replaced the JSON.parse/stringify round-trip with a surgical regex replace of just the `"version"` line — matching the approach `bloqr-compiler`'s own `sync-version.ts` already uses for `wrangler.toml`'s `COMPILER_VERSION` field (see `docs/architecture/versioning-strategy.md`). Everything else in the file, including the comments, is left untouched byte-for-byte.

## Verification

- No-op case (already synced): confirmed skips correctly, no file write
- Real bump case: temporarily set `VERSION` to `1.0.1`, ran `version:sync`, confirmed `deno.json`'s version field updated correctly and all 8 comment lines survived untouched; reverted
- `deno check scripts/sync-version.ts` — clean
- `deno lint scripts/sync-version.ts` — clean
- `deno publish --dry-run` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Njq8s2j9cXsSBoYMjocwHN)_