### PR TITLE
ci: full Dependabot ecosystem coverage + Deno/JSR dependency workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,160 @@
 # Please see the documentation for more information:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 # https://containers.dev/guide/dependabot
+#
+# Coverage note: Dependabot has no native `jsr:` ecosystem, so pure
+# JSR-native imports in src/adblock-compiler-core/deno.json (jsr:@std/*,
+# jsr:@bloqr/*, etc.) are NOT covered by anything below — Dependabot's npm
+# ecosystem can pick up Deno's npm: shorthand specifiers from a deno.lock,
+# but not jsr: ones. That gap is covered separately by the scheduled
+# `deno-dependency-check.yml` workflow, which runs `deno outdated` and
+# opens a PR the same way the manual npm/cargo/nuget/pip ecosystems below
+# do. See docs/RESTRUCTURING_RETROSPECTIVE.md for why this split exists.
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    commit-message:
+      prefix: "chore(devcontainer)"
+    labels:
+      - dependencies
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - dependencies
+      - ci
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # npm: root package.json (Claude Agent SDK) and Deno's npm: shorthand
+  # imports in src/adblock-compiler-core/deno.json / deno.lock. Does NOT
+  # cover jsr: imports in that same file -- see deno-dependency-check.yml.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # npm: Gatsby documentation site, separate package.json/lockfile.
+  - package-ecosystem: "npm"
+    directory: "/src/website"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(website)"
+    labels:
+      - dependencies
+      - website
+    groups:
+      gatsby-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # cargo: workspace root covers rules-compiler-rust and both
+  # rules-validator crates (workspace members), no separate entries needed.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(rust)"
+    labels:
+      - dependencies
+      - rust
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # nuget: central package management (Directory.Packages.props at repo
+  # root) covers every nested .csproj under src/rules-compiler-dotnet/.
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(dotnet)"
+    labels:
+      - dependencies
+      - dotnet
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pip"
+    directory: "/src/rules-compiler-python"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(python)"
+    labels:
+      - dependencies
+      - python
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(docker)"
+    labels:
+      - dependencies
+      - docker

--- a/.github/workflows/deno-dependency-check.yml
+++ b/.github/workflows/deno-dependency-check.yml
@@ -1,0 +1,117 @@
+name: Deno/JSR Dependency Check
+
+# Dependabot has no native `jsr:` ecosystem, so pure JSR-native imports in
+# src/adblock-compiler-core/deno.json (jsr:@std/*, jsr:@bloqr/*, etc.) get
+# no automated update coverage from dependabot.yml -- only Deno's npm:
+# shorthand imports do. This workflow closes that gap using Deno's own
+# `deno outdated` command, on the same weekly cadence as Dependabot, and
+# opens a PR the same way compiler-core-version-bump.yml does: a human
+# reviews and merges, nothing auto-merges here.
+#
+# Scoped to src/adblock-compiler-core specifically (the one real JSR
+# package in this repo today) -- extend the `directory` / branch name /
+# PR title below, or copy this file, when a second JSR package exists.
+# See docs/architecture/versioning-strategy.md for the per-package
+# convention this mirrors.
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Monday 09:00 UTC, alongside Dependabot's weekly runs
+  workflow_dispatch:
+    inputs:
+      latest:
+        description: "Ignore semver ranges and update to the latest version of every dependency (deno outdated --update --latest) instead of the default semver-compatible update"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check:
+    name: Check for outdated JSR/npm dependencies
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/adblock-compiler-core
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Update dependencies
+        id: update
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.latest }}" = "true" ]; then
+            deno outdated --update --latest
+          else
+            deno outdated --update
+          fi
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet -- deno.json deno.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify updated dependencies still build and test cleanly
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          deno task check
+          deno task lint
+          deno task test
+          deno publish --dry-run --allow-dirty
+
+      - name: Create PR with dependency updates
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          BRANCH_NAME="auto-deno-outdated-$(date +%Y%m%d)"
+          git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+          git checkout -b "$BRANCH_NAME"
+          git add deno.json deno.lock
+          git commit -m "chore(deps): update JSR/npm dependencies via deno outdated"
+          git push -u origin "$BRANCH_NAME"
+
+          gh pr create \
+            --title "chore(deps): update compiler-core JSR/npm dependencies" \
+            --body "$(cat <<'EOF'
+          ## Automated dependency update
+
+          Opened by the `deno-dependency-check.yml` workflow, which runs
+          `deno outdated --update` on the same weekly cadence as Dependabot,
+          to cover `jsr:` dependencies in `src/adblock-compiler-core/deno.json`
+          that Dependabot's ecosystems don't reach.
+
+          `deno task check`, `deno task lint`, `deno task test`, and
+          `deno publish --dry-run` all passed in CI before this PR was opened.
+          Review the diff for any semver-compatible-but-behaviorally-different
+          changes before merging -- this is not auto-merged.
+          EOF
+          )" \
+            --base main \
+            --head "$BRANCH_NAME" \
+            --label dependencies
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ "${{ steps.diff.outputs.changed }}" = "true" ]; then
+            echo "## 📦 Dependency update PR opened" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## ✅ No outdated JSR/npm dependencies found" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/src/adblock-compiler-core/deno.json
+++ b/src/adblock-compiler-core/deno.json
@@ -38,9 +38,9 @@
     "generate:types": "deno run --allow-read --allow-write --no-npm generate-types.ts"
   },
   "imports": {
-    "@std/assert": "jsr:@std/assert@^1.0.18",
-    "@std/testing": "jsr:@std/testing@^1.0.18",
-    "@std/path": "jsr:@std/path@^1.1.5",
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/testing": "jsr:@std/testing@^1.0.20",
+    "@std/path": "jsr:@std/path@^1.1.6",
     "@std/yaml": "jsr:@std/yaml@^1.2.0",
     "@std/toml": "jsr:@std/toml@^1.0.11",
     "@std/fmt": "jsr:@std/fmt@^1.0.10",

--- a/src/adblock-compiler-core/deno.lock
+++ b/src/adblock-compiler-core/deno.lock
@@ -2,14 +2,17 @@
   "version": "5",
   "specifiers": {
     "jsr:@cliffy/table@^1.2.1": "1.2.1",
-    "jsr:@std/assert@^1.0.18": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@^1.5.0": "1.5.0",
     "jsr:@std/collections@^1.1.3": "1.3.0",
+    "jsr:@std/data-structures@^1.1.2": "1.1.2",
     "jsr:@std/fmt@^1.0.10": "1.0.10",
+    "jsr:@std/fs@^1.0.24": "1.0.24",
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/path@^1.1.5": "1.1.6",
-    "jsr:@std/testing@^1.0.18": "1.0.20",
+    "jsr:@std/path@^1.1.6": "1.1.6",
+    "jsr:@std/testing@^1.0.20": "1.0.20",
     "jsr:@std/toml@^1.0.11": "1.0.11",
     "jsr:@std/yaml@^1.2.0": "1.2.0",
     "jsr:@zod/zod@^4.4.3": "4.4.3",
@@ -30,11 +33,23 @@
         "jsr:@std/internal@^1.0.12"
       ]
     },
+    "@std/async@1.5.0": {
+      "integrity": "4c1f22d287a17ad7d8643b1952bc5a4d21e5d8b68dc8c20d8268eecc69096e82"
+    },
     "@std/collections@1.3.0": {
       "integrity": "eb36b43d784477ea0b476483ac034a14bdd182aff921c812ecf662a1fcef9498"
     },
+    "@std/data-structures@1.1.2": {
+      "integrity": "2471377c9e0051f9ec34e57d0ebd0ad133a5a889677446ec6ba9938e4e102918"
+    },
     "@std/fmt@1.0.10": {
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
+    },
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
+      "dependencies": [
+        "jsr:@std/path@^1.1.5"
+      ]
     },
     "@std/internal@1.0.14": {
       "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
@@ -48,7 +63,12 @@
     "@std/testing@1.0.20": {
       "integrity": "21380ed438672762e4ec549cbf4fe41c5b68f5598773a30b64abe7375513e721",
       "dependencies": [
-        "jsr:@std/assert@^1.0.19"
+        "jsr:@std/assert",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs",
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.6"
       ]
     },
     "@std/toml@1.0.11": {
@@ -314,10 +334,10 @@
   "workspace": {
     "dependencies": [
       "jsr:@cliffy/table@^1.2.1",
-      "jsr:@std/assert@^1.0.18",
+      "jsr:@std/assert@^1.0.19",
       "jsr:@std/fmt@^1.0.10",
-      "jsr:@std/path@^1.1.5",
-      "jsr:@std/testing@^1.0.18",
+      "jsr:@std/path@^1.1.6",
+      "jsr:@std/testing@^1.0.20",
       "jsr:@std/toml@^1.0.11",
       "jsr:@std/yaml@^1.2.0",
       "jsr:@zod/zod@^4.4.3",


### PR DESCRIPTION
## Summary

`.github/dependabot.yml` previously configured only the `devcontainers` ecosystem — no automated version-update coverage for npm, Cargo, NuGet, pip, GitHub Actions, or Docker, despite this being a genuinely multi-language repo with real manifests in every one of those ecosystems. GitHub currently shows **54 open Dependabot security alerts** (28 high / 17 moderate / 9 low) on this repo — with essentially no ecosystems configured for automated remediation, that's not surprising, and it was going to keep growing as Epic #256 adds more surface area (the Dashboard app, more compiler wrappers).

I don't have a tool in this session that can enumerate individual alert CVEs to hand-triage them one by one — but I can, and did, fix the actual systemic gap. Once this merges, Dependabot's normal auto-remediation kicks in: it opens PRs bumping vulnerable dependencies to patched versions across every configured ecosystem, which is what actually closes most existing alerts (rather than requiring one-by-one manual triage of each).

## Changes

**`.github/dependabot.yml`** — added 7 ecosystem entries, modeled on `bloqr-compiler`'s already-mature config (weekly Monday 09:00 America/New_York, commit-message prefixes, `dependencies` label, grouped minor/patch updates to avoid PR spam):

| Ecosystem | Directory | Covers |
|---|---|---|
| `github-actions` | `/` | Workflow action pins |
| `npm` | `/` | Root `package.json` (Claude Agent SDK) + Deno's `npm:` shorthand imports in `src/adblock-compiler-core` |
| `npm` | `/src/website` | Gatsby documentation site |
| `cargo` | `/` | Workspace root — covers `rules-compiler-rust` and both `rules-validator` crates automatically |
| `nuget` | `/` | Central package management (`Directory.Packages.props` at repo root) — covers every nested `.csproj` under `src/rules-compiler-dotnet/` |
| `pip` | `/src/rules-compiler-python` | Python compiler |
| `docker` | `/` | `Dockerfile.warp` |

`devcontainers` (pre-existing) kept as-is.

**`.github/workflows/deno-dependency-check.yml`** (new) — Dependabot has no native `jsr:` ecosystem, so pure JSR-native imports (`jsr:@std/*`, `jsr:@bloqr/*`) in `src/adblock-compiler-core/deno.json` aren't covered by anything above. This workflow closes that specific gap: runs `deno outdated --update` weekly (same cadence as Dependabot), verifies `check`/`lint`/`test`/`publish --dry-run` all still pass, and opens a PR for human review — mirroring the exact detect → branch → commit → PR pattern `compiler-core-version-bump.yml` already uses. Nothing here auto-merges.

**`src/adblock-compiler-core/deno.json` / `deno.lock`** — ran the new workflow's logic manually to confirm it actually works end to end, not just in theory. Found and applied 3 real updates:
- `@std/assert` `^1.0.18` → `^1.0.19`
- `@std/path` `^1.1.5` → `^1.1.6`
- `@std/testing` `^1.0.18` → `^1.0.20`

## Verification

- Both new/changed YAML files validated with a parser.
- `deno outdated --update` run locally against `src/adblock-compiler-core` — confirmed it finds and applies real updates.
- Post-update: `deno task check`, `deno task lint`, `deno task test` (1008/1008 passing), `deno publish --dry-run` — all pass.

## Not covered by this PR

- Individual Dependabot alert triage — no tool available in this session to enumerate/read specific CVE details. This PR fixes the systemic cause; expect a wave of Dependabot-generated remediation PRs over the next few days as it catches up across every newly-configured ecosystem.
- `bloqr-compiler` has its own Deno/JSR gap (10 `jsr:` imports, no `deno-dependency-check.yml` equivalent) and two Dockerfiles not in its `dependabot.yml`. Flagged separately, not in scope for this repo's PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Njq8s2j9cXsSBoYMjocwHN)_