### PR TITLE
fix(ci): pause after push to avoid startup_failure race in automated PR workflows

### DIFF
--- a/.github/workflows/compiler-core-version-bump.yml
+++ b/.github/workflows/compiler-core-version-bump.yml
@@ -195,6 +195,13 @@ jobs:
           git commit -m "chore: bump compiler-core version to ${{ steps.bump.outputs.new }}"
           git push -u origin "$BRANCH_NAME"
 
+          # GitHub's ref/event ingestion can lag a couple of seconds behind a
+          # push. Opening the PR immediately after push has been observed
+          # (in bloqr-compiler's equivalent workflows) to race that lag and
+          # produce a "startup_failure" CI run with zero jobs. A short pause
+          # here avoids that race.
+          sleep 10
+
           gh pr create \
             --title "chore: bump @bloqr/compiler-core version to ${{ steps.bump.outputs.new }}" \
             --body "$(cat <<EOF

--- a/.github/workflows/deno-dependency-check.yml
+++ b/.github/workflows/deno-dependency-check.yml
@@ -87,6 +87,13 @@ jobs:
           git commit -m "chore(deps): update JSR/npm dependencies via deno outdated"
           git push -u origin "$BRANCH_NAME"
 
+          # GitHub's ref/event ingestion can lag a couple of seconds behind a
+          # push. Opening the PR immediately after push has been observed
+          # (in bloqr-compiler's equivalent workflows) to race that lag and
+          # produce a "startup_failure" CI run with zero jobs. A short pause
+          # here avoids that race.
+          sleep 10
+
           gh pr create \
             --title "chore(deps): update compiler-core JSR/npm dependencies" \
             --body "$(cat <<'EOF'


### PR DESCRIPTION
## Summary

While triaging PR #2215 in `bloqr-compiler` I found its `ci.yml` run failing with `startup_failure` and zero jobs, on a branch pushed and immediately used to open a PR / dispatch CI by an automated workflow. The same pattern also hit `bloqr-compiler`'s Cloudflare dependency update PRs (#2210 and its predecessor). Root cause: `gh pr create` / `gh workflow run` running immediately after `git push -u origin <branch>` can race GitHub's ref/event ingestion, which occasionally isn't done processing the newly pushed ref yet.

This repo's `compiler-core-version-bump.yml` and `deno-dependency-check.yml` follow the identical push-then-immediately-open-PR pattern, so they're exposed to the same race even though it hasn't been observed here yet.

## Changes
- `compiler-core-version-bump.yml`: added a 10s pause after `git push -u origin "$BRANCH_NAME"`, before `gh pr create`.
- `deno-dependency-check.yml`: same fix, same location.

## Test plan
- [x] Verified via `grep` that no other workflow in this repo follows the push-then-trigger pattern without this fix.
- N/A for functional testing — this only adds a `sleep` between two existing steps in bot-only workflows; no logic changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Njq8s2j9cXsSBoYMjocwHN)_