### PR TITLE
feat(compiler-core): formally support Bun as a runtime target

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -64,3 +64,74 @@ jobs:
       - name: Test
         if: matrix.has_tests
         run: deno task test
+
+  bun-support:
+    name: Bun Runtime Support
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/adblock-compiler-core
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # `bunx jsr add` is JSR's own documented installer bridge for Bun
+      # projects (https://jsr.io/docs/with/bun) — it materializes JSR
+      # packages into node_modules from their npm-compatible mirror, since
+      # Bun (unlike Deno) has no import-map concept and can't resolve this
+      # package's bare `@std/*`/`@cliffy/*` specifiers from deno.json alone.
+      - name: Install JSR dependencies for Bun
+        run: bunx jsr add @std/yaml @std/toml @std/fmt @cliffy/table
+
+      # zod is aliased to the bare `zod` specifier in deno.json's import map
+      # (`"zod": "jsr:@zod/zod@^4.4.3"`), so it needs an explicit alias here
+      # too — `bunx jsr add @zod/zod` would install it under the scoped name
+      # instead, which the bare `from 'zod'` imports wouldn't resolve.
+      - name: Install zod (aliased) for Bun
+        run: bun add zod@npm:@jsr/zod__zod@^4.4.3
+
+      # ora, figlet, and @inquirer/prompts are npm-native (no JSR-native
+      # equivalent exists — see the comments next to these entries in
+      # deno.json), so they install directly.
+      - name: Install npm-native CLI dependencies for Bun
+        run: bun add ora figlet @inquirer/prompts
+
+      - name: Smoke test — Bun entry point reports itself correctly
+        run: |
+          set -euo pipefail
+          OUTPUT="$(bun run src/mod.bun.ts --version)"
+          echo "$OUTPUT"
+          echo "$OUTPUT" | grep -q "Runtime: Bun" || {
+            echo "::error::Bun entry point did not report itself as the Bun runtime"
+            exit 1
+          }
+
+      - name: Smoke test — validate the sample configuration under Bun
+        run: bun run src/mod.bun.ts --validate -c compiler-config.json
+
+      - name: Smoke test — library API (compile()) under Bun
+        run: |
+          set -euo pipefail
+          cat > /tmp/bun-lib-smoke-input.txt <<'EOF'
+          ! comment
+          ||example.com^
+          ||example.com^
+          EOF
+          cat > bun-lib-smoke.ts <<'EOF'
+          import { compile } from './src/index.ts';
+          const result = await compile({
+            name: 'bun-ci-smoke-test',
+            sources: [{ source: '/tmp/bun-lib-smoke-input.txt', type: 'adblock' }],
+            transformations: ['RemoveComments', 'Deduplicate'],
+          });
+          if (!result.includes('||example.com^')) {
+            throw new Error(`Unexpected compile() output: ${JSON.stringify(result)}`);
+          }
+          console.log('library API smoke test passed:', JSON.stringify(result));
+          EOF
+          bun run bun-lib-smoke.ts
+          rm -f bun-lib-smoke.ts /tmp/bun-lib-smoke-input.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,36 @@ GitHub Actions workflows validate:
 - Full narrative, including the OIDC investigation timeline and the
   `bloqr-compiler` dependency-swap decisions, is in
   `docs/RESTRUCTURING_RETROSPECTIVE.md`.
+- **TypeScript/JavaScript runtime and package-manager order of preference,
+  for every project in this repo:**
+  1. **Deno-native first.** Design new TypeScript code, and structure new
+     projects, to run under Deno without a build step. Reach for Deno's own
+     standard library and tasks before anything from the npm ecosystem.
+  2. **JSR packages before npm packages.** When a dependency is needed,
+     check JSR first; only fall back to `npm:` specifiers in `deno.json`
+     when no JSR-native equivalent exists (and say so in a comment next to
+     the import, matching the existing `ora`/`figlet`/`@inquirer/prompts`
+     entries in `src/adblock-compiler-core/deno.json`).
+  3. **Bun is a formally supported runtime target, not a fallback.**
+     Consumer-facing TypeScript packages (e.g. `@bloqr/compiler-core`)
+     should work correctly under Bun as well as Deno — no unguarded
+     `Deno.*` references outside code explicitly documented as Deno-only —
+     and that support should be verified by real CI against real Bun, not
+     just asserted in docs. Node.js compatibility follows for free from
+     the same `node:*` API shims Bun itself relies on; it is not a runtime
+     this repo targets on its own.
+  4. **pnpm only when npm/Node-ecosystem tooling is genuinely required**
+     (e.g. the Gatsby website), and even then prefer it over plain `npm`.
+     Avoid introducing a `package.json` to a Deno-native project just to
+     install one npm-only dependency — use `deno.json`'s `npm:` import
+     specifiers instead, which don't require one.
+  5. **Cloudflare Workers is this org's cloud-native deploy target** for
+     anything that needs to run as a service — see `bloqr-compiler` for
+     the reference implementation (Workers, Hyperdrive, D1, Durable
+     Objects). Gatsby-based `src/website` is a deliberate exception (no
+     meaningful Deno-native static-site-generator option exists) and is
+     expected to eventually move to Starlight in `bloqr-compiler`, not stay
+     on Gatsby indefinitely.
 
 ## Prerequisites
 
@@ -408,6 +438,7 @@ GitHub Actions workflows validate:
 | Python | 3.9+ | Python compiler |
 | Rust | 1.85+ | Rust compiler (install via rustup) |
 | @bloqr/compiler-core | 1.0.0 | TypeScript compiler (via JSR: `deno add @bloqr/compiler-core`) |
+| Bun | latest | Optional — formally supported alternative runtime target for `src/adblock-compiler-core` (not required for this repo's own tooling; see that package's README) |
 | Docker | 24.0+ | Container development (optional but recommended) |
 
 ## Key File Locations

--- a/src/adblock-compiler-core/CHANGELOG.md
+++ b/src/adblock-compiler-core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@bloqr/compiler-core` (formerly `@jk-com/adblock-compile
 
 ## [Unreleased]
 
+### Added
+
+- **cli**: Add Bun as a formally supported runtime target (`src/mod.bun.ts`, exported as `./bun`) alongside Deno. `getVersionInfo()`/`showVersion()` now correctly identify the Bun runtime (`Runtime: Bun x.y.z`) instead of erroring, `main()`'s default argument list and `findDefaultConfig()`'s default base path use `node:process` when the `Deno` global isn't present, and environment-variable reads (`DEBUG`, `LOG_LEVEL`, `LOG_FORMAT`, `LOG_MODULE_OVERRIDES`, `LOG_STRUCTURED`, plus `EnvConfigurationSource`) fall back to `process.env` instead of silently returning nothing. CI (`bun-support` job in `.github/workflows/typescript.yml`) installs this package's JSR/npm dependencies for Bun and runs CLI + library smoke tests against real Bun on every PR. See `README.md`'s "Bun (Supported)" section.
+- **fix**: `ShutdownHandler` (`orchestration/shutdown.ts`) previously called `globalThis.addEventListener('unhandledrejection', ...)` unconditionally, which Node.js does not implement at all (Bun does, but the module was documented "Deno-only" and untested there) — this would have thrown under Node.js on every CLI invocation reaching `initializeShutdownHandler()`. Signal handling (`SIGTERM`/`SIGINT`/`SIGHUP`) and unhandled-rejection reporting now use `process.on(...)` when the `Deno` global isn't present.
+
 ### Changed
 
 - **Breaking**: package renamed from `@jk-com/adblock-compiler` to `@bloqr/compiler-core`. `@jk-com` was a personal-project JSR scope; all Bloqr JSR packages (this one, and future ones like `@bloqr/diagnostics`) now live under the `@bloqr` scope. No functional changes — same package contents, same exports, just a new name and scope. See `README.md`'s Architecture section for the full story.

--- a/src/adblock-compiler-core/README.md
+++ b/src/adblock-compiler-core/README.md
@@ -16,7 +16,8 @@ This is the canonical source for the `@bloqr/compiler-core` JSR package. It's a 
 
 ## Requirements
 
-- Deno 2.x or later
+- Deno 2.x or later (this package's own runtime)
+- [Bun](https://bun.sh/) is supported as an alternative runtime target for consumers — see [Bun (Supported)](#bun-supported) below. Node.js works too, since Bun's compatibility layer is the same one Node.js implements, but Deno and Bun are the two runtimes this package is actually verified against.
 
 ## Installation
 
@@ -137,6 +138,31 @@ deno task start -- --enable-chunking --chunk-size 50000 --max-parallel 4
 - Very large individual sources (1M+ rules)
 - Multi-core systems with available CPU resources
 
+### Bun (Supported)
+
+[Bun](https://bun.sh/) is supported as an alternative runtime target. As a library, `import { compile } from '@bloqr/compiler-core'` works under Bun with no setup beyond installing the package. The CLI/interactive layer (`src/orchestration/`, `src/console/`) additionally depends on a few JSR and npm packages that Bun — unlike Deno — can't resolve from `deno.json`'s import map, so populate `node_modules` first, from a local clone of this package:
+
+```bash
+# JSR packages, via JSR's own Bun installer bridge (https://jsr.io/docs/with/bun)
+bunx jsr add @std/yaml @std/toml @std/fmt @cliffy/table
+
+# zod is aliased to the bare `zod` specifier (matching deno.json's import map),
+# so it needs an explicit alias rather than `bunx jsr add @zod/zod`
+bun add zod@npm:@jsr/zod__zod@^4.4.3
+
+# npm-native packages with no JSR-native equivalent
+bun add ora figlet @inquirer/prompts
+```
+
+Then run the CLI via the dedicated Bun entry point (mirrors `src/mod.ts`, the Deno entry point):
+
+```bash
+bun run src/mod.bun.ts -c compiler-config.json -o output.txt
+bun run src/mod.bun.ts --version   # reports "Runtime: Bun x.y.z"
+```
+
+Deno remains this package's own runtime and JSR remains the source of truth for its dependencies (`deno.json`) — the `node_modules` population above is only for Bun consumers running this package's CLI/interactive layer directly, not something this repository's own tooling uses. CI (`.github/workflows/typescript.yml`, `bun-support` job) runs these exact install commands and CLI/library smoke tests against real Bun on every PR.
+
 ### Generate Type Definitions
 
 To generate TypeScript declaration files (`.d.ts`):
@@ -165,6 +191,7 @@ This creates `.d.ts` files in the `dist/` directory that re-export types from th
 - `src/console/` — the interactive terminal UI, exported as `./console`.
 - `src/lib/` — a high-level builder-pattern API (`RulesCompiler`, `ConfigurationBuilder`), exported as `./lib`.
 - `src/mod.ts` — the Deno entry point; re-exports the core engine and runs the CLI when executed directly.
+- `src/mod.bun.ts` — the Bun entry point (exported as `./bun`), for the same purpose from a local clone; see [Bun (Supported)](#bun-supported).
 
 ## Architecture
 

--- a/src/adblock-compiler-core/deno.json
+++ b/src/adblock-compiler-core/deno.json
@@ -7,7 +7,8 @@
     "./lib": "./src/lib/index.ts",
     "./orchestration": "./src/orchestration/index.ts",
     "./console": "./src/console/index.ts",
-    "./cli": "./src/orchestration/cli.ts"
+    "./cli": "./src/orchestration/cli.ts",
+    "./bun": "./src/mod.bun.ts"
   },
   "publish": {
     "include": [
@@ -30,7 +31,7 @@
     "dev": "deno run --allow-read --allow-write --allow-env --allow-net --allow-run --watch src/mod.ts",
     "test": "deno test --allow-read --allow-write --allow-env --allow-net src/",
     "test:coverage": "deno test --allow-read --allow-write --allow-env --allow-net --coverage=coverage src/",
-    "check": "deno check src/mod.ts",
+    "check": "deno check src/mod.ts src/mod.bun.ts",
     "lint": "deno lint src/",
     "fmt": "deno fmt src/",
     "version": "deno run --allow-read --allow-env src/mod.ts --version",

--- a/src/adblock-compiler-core/src/configuration/sources/index.ts
+++ b/src/adblock-compiler-core/src/configuration/sources/index.ts
@@ -14,6 +14,7 @@
  * @module
  */
 
+import process from 'node:process';
 import type { IConfiguration, IFileSystem } from '../../types/index.ts';
 import { ConfigurationLoader } from '../ConfigurationLoader.ts';
 
@@ -94,7 +95,8 @@ export class ObjectConfigurationSource implements IConfigurationSource {
  * | `ADBLOCK_CONFIG_VERSION`      | `version`                |
  *
  * @param envReader  - Optional injected reader for testability (defaults to
- *                     `Deno.env.get`).
+ *                     `Deno.env.get` under Deno, `process.env` under
+ *                     Node.js/Bun).
  *
  * @example
  * ```ts
@@ -107,9 +109,8 @@ export class EnvConfigurationSource implements IConfigurationSource {
   private readonly envReader: (key: string) => string | undefined;
 
   constructor(envReader?: (key: string) => string | undefined) {
-    // deno-lint-ignore no-explicit-any
     this.envReader = envReader ??
-      ((key) => (typeof Deno !== 'undefined' && (Deno as any).env ? Deno.env.get(key) : undefined));
+      ((key) => (typeof Deno !== 'undefined' && Deno.env ? Deno.env.get(key) : process.env[key]));
   }
 
   async load(): Promise<Partial<IConfiguration>> {

--- a/src/adblock-compiler-core/src/console/app.ts
+++ b/src/adblock-compiler-core/src/console/app.ts
@@ -422,11 +422,13 @@ export class ConsoleApplication {
     table.push(['Module', info.moduleVersion]);
     table.push(['Runtime', info.nodeVersion]);
     table.push(['Platform', `${info.platform.os} ${info.platform.arch}`]);
-    table.push([
-      'TypeScript',
-      (Deno as unknown as { version: { typescript: string } }).version.typescript,
-    ]);
-    table.push(['V8', (Deno as unknown as { version: { v8: string } }).version.v8]);
+
+    // TypeScript/V8 versions are only meaningful (and only available without
+    // a ReferenceError) when actually running under Deno.
+    if (typeof Deno !== 'undefined') {
+      table.push(['TypeScript', Deno.version.typescript]);
+      table.push(['V8', Deno.version.v8]);
+    }
 
     displayTable(table);
   }

--- a/src/adblock-compiler-core/src/mod.bun.ts
+++ b/src/adblock-compiler-core/src/mod.bun.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env bun
+/**
+ * adblock-compiler-core — Bun Entry Point
+ *
+ * Bun implements Node's `fs`/`process` APIs natively, and `orchestration/cli.ts`'s
+ * `main()` already detects the runtime itself, so no Bun-specific wiring is
+ * needed here — this file exists purely as the documented, explicit entry
+ * point for Bun users, mirroring `./mod.ts` (the Deno entry point). Bun is a
+ * supported *runtime target* for consumers of this package; Deno remains this
+ * project's own runtime.
+ *
+ * Run with `bun run src/mod.bun.ts [args]` from a local clone, after
+ * installing this package's npm/JSR dependencies for Bun (see README.md).
+ *
+ * @module
+ */
+
+// Re-export the core compilation engine
+export * from './index.ts';
+
+import process from 'node:process';
+import { main } from './orchestration/cli.ts';
+
+// Run if executed directly
+if (import.meta.main) {
+  const exitCode = await main(process.argv.slice(2));
+  process.exit(exitCode);
+}

--- a/src/adblock-compiler-core/src/orchestration/cli.ts
+++ b/src/adblock-compiler-core/src/orchestration/cli.ts
@@ -5,7 +5,11 @@
  * Production-ready with graceful shutdown and structured error handling.
  * Supports both interactive menu mode and non-interactive command-line
  * mode (argument parsing, help/version output, and the {@linkcode main}
- * entry point used by the `cli` export subpath). Deno-only implementation.
+ * entry point used by the `cli` export subpath). Deno is this package's
+ * own runtime; Node.js and Bun are also supported (see {@link ./mod.bun.ts}
+ * for the explicit Bun entry point) since neither `main` nor its
+ * dependencies call `Deno.*` without first checking the `Deno` global is
+ * present.
  *
  * @example Parse arguments and run the CLI
  * ```ts
@@ -19,6 +23,7 @@
  */
 
 import { resolve } from 'node:path';
+import process from 'node:process';
 import type { CliOptions, ConfigurationFormat, VersionInfo } from './types.ts';
 import { runCompiler } from './compiler.ts';
 import { findDefaultConfig, readConfiguration, toJson } from './config-reader.ts';
@@ -217,12 +222,28 @@ Examples:
  * @returns Version info object
  */
 export function getVersionInfo(): VersionInfo {
+  if (typeof Deno !== 'undefined') {
+    return {
+      moduleVersion: VERSION,
+      nodeVersion: `Deno ${Deno.version.deno}`,
+      platform: {
+        os: Deno.build.os,
+        arch: Deno.build.arch,
+      },
+    };
+  }
+
+  // Node.js and Bun both land here. Index through `globalThis` (rather than
+  // referencing a bare `Bun` identifier) so this still type-checks under
+  // `deno check`, which has no ambient `Bun` type.
+  const bunVersion = (globalThis as { Bun?: { version?: string } }).Bun?.version;
+
   return {
     moduleVersion: VERSION,
-    nodeVersion: `Deno ${Deno.version.deno}`,
+    nodeVersion: bunVersion ? `Bun ${bunVersion}` : `Node.js ${process.version}`,
     platform: {
-      os: Deno.build.os,
-      arch: Deno.build.arch,
+      os: process.platform,
+      arch: process.arch,
     },
   };
 }
@@ -240,8 +261,13 @@ export function showVersion(): void {
   console.log(`  OS: ${info.platform.os}`);
   console.log(`  Architecture: ${info.platform.arch}`);
   console.log(`  Runtime: ${info.nodeVersion}`);
-  console.log(`  TypeScript: ${Deno.version.typescript}`);
-  console.log(`  V8: ${Deno.version.v8}`);
+
+  // TypeScript/V8 versions are only meaningful (and only available without a
+  // ReferenceError) when actually running under Deno.
+  if (typeof Deno !== 'undefined') {
+    console.log(`  TypeScript: ${Deno.version.typescript}`);
+    console.log(`  V8: ${Deno.version.v8}`);
+  }
 }
 
 /**
@@ -402,7 +428,9 @@ async function runValidationMode(
  * @param args - Command line arguments
  * @returns Exit code
  */
-export async function main(args: string[] = Deno.args): Promise<number> {
+export async function main(
+  args: string[] = typeof Deno !== 'undefined' ? Deno.args : process.argv.slice(2),
+): Promise<number> {
   let shutdownHandler: ShutdownHandler | undefined;
 
   try {
@@ -532,7 +560,13 @@ export async function main(args: string[] = Deno.args): Promise<number> {
 }
 
 // Run if executed directly
+// `import.meta.main` is supported by both Deno and Bun (Node.js does not set
+// it), so this direct-execution path needs the same runtime-detected exit.
 if (import.meta.main) {
   const code = await main();
-  Deno.exit(code);
+  if (typeof Deno !== 'undefined') {
+    Deno.exit(code);
+  } else {
+    process.exit(code);
+  }
 }

--- a/src/adblock-compiler-core/src/orchestration/config-reader.ts
+++ b/src/adblock-compiler-core/src/orchestration/config-reader.ts
@@ -5,6 +5,7 @@
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { extname, resolve } from 'node:path';
+import process from 'node:process';
 import { parse as parseYaml } from '@std/yaml';
 import { parse as parseToml } from '@std/toml';
 import type { IConfiguration } from '../index.ts';
@@ -113,10 +114,14 @@ const DEFAULT_CONFIG_PATHS = [
 
 /**
  * Finds a default configuration file
- * @param basePath - Base path to search from
+ * @param basePath - Base path to search from; defaults to the current working
+ *   directory (Deno-native when available, otherwise `node:process`, which
+ *   Node.js and Bun both implement).
  * @returns Path to config file or undefined
  */
-export function findDefaultConfig(basePath: string = Deno.cwd()): string | undefined {
+export function findDefaultConfig(
+  basePath: string = typeof Deno !== 'undefined' ? Deno.cwd() : process.cwd(),
+): string | undefined {
   for (const configPath of DEFAULT_CONFIG_PATHS) {
     const fullPath = resolve(basePath, configPath);
     if (existsSync(fullPath)) {

--- a/src/adblock-compiler-core/src/orchestration/logger.ts
+++ b/src/adblock-compiler-core/src/orchestration/logger.ts
@@ -3,6 +3,7 @@
  * Supports both human-readable and structured (JSON) output formats
  */
 
+import process from 'node:process';
 import type { Logger } from './types.ts';
 
 /**
@@ -98,13 +99,13 @@ export function createLogger(config: Partial<LoggerConfig> | boolean = false): E
     ? { ...DEFAULT_CONFIG, debugEnabled: config }
     : { ...DEFAULT_CONFIG, ...config };
 
-  // Helper to get environment variables
+  // Helper to get environment variables. Prefers Deno's API when available,
+  // falling back to `node:process` (Node.js and Bun) otherwise.
   const getEnv = (key: string): string | undefined => {
-    try {
+    if (typeof Deno !== 'undefined' && Deno.env) {
       return Deno.env.get(key);
-    } catch {
-      return undefined;
     }
+    return process.env[key];
   };
 
   // Check environment variables
@@ -231,14 +232,14 @@ export function createLogger(config: Partial<LoggerConfig> | boolean = false): E
 }
 
 /**
- * Helper to get environment variable
+ * Helper to get environment variable. Prefers Deno's API when available,
+ * falling back to `node:process` (Node.js and Bun) otherwise.
  */
 function getEnvVar(key: string): string | undefined {
-  try {
+  if (typeof Deno !== 'undefined' && Deno.env) {
     return Deno.env.get(key);
-  } catch {
-    return undefined;
   }
+  return process.env[key];
 }
 
 /**

--- a/src/adblock-compiler-core/src/orchestration/shutdown.ts
+++ b/src/adblock-compiler-core/src/orchestration/shutdown.ts
@@ -1,9 +1,18 @@
 /**
  * Graceful shutdown handler for production deployments
  * Handles SIGTERM, SIGINT signals and cleanup
- * Deno-only implementation
+ *
+ * Deno-native, with a Node.js/Bun fallback: signal registration uses
+ * `Deno.addSignalListener` when the `Deno` global is present, otherwise
+ * `process.on(signal, ...)` (which both Node.js and Bun implement).
+ * Likewise, unhandled-rejection reporting uses Deno's
+ * `globalThis.addEventListener('unhandledrejection', ...)` under Deno and
+ * `process.on('unhandledRejection', ...)` otherwise — Node.js does not
+ * implement `globalThis.addEventListener` for process-level events at all,
+ * so this fallback is required, not just a compatibility nicety.
  */
 
+import process from 'node:process';
 import { ShutdownError } from './errors.ts';
 import type { Logger } from './types.ts';
 
@@ -78,6 +87,7 @@ export class ShutdownHandler {
    */
   listen(): void {
     const signals: DenoSignal[] = ['SIGTERM', 'SIGINT', 'SIGHUP'];
+    const isDeno = typeof Deno !== 'undefined';
 
     for (const signal of signals) {
       const handler = (): void => {
@@ -85,19 +95,32 @@ export class ShutdownHandler {
       };
       this.signalHandlers.set(signal, handler);
       try {
-        Deno.addSignalListener(signal, handler);
+        if (isDeno) {
+          Deno.addSignalListener(signal, handler);
+        } else {
+          process.on(signal, handler);
+        }
       } catch {
         // Signal may not be available on all platforms
         this.logger?.debug(`Signal ${signal} not available on this platform`);
       }
     }
 
-    // Handle unhandled rejections using globalThis event listener
-    globalThis.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
-      const reason = event.reason;
-      const message = reason instanceof Error ? reason.message : String(reason);
-      this.logger?.error(`Unhandled rejection: ${message}`);
-    });
+    if (isDeno) {
+      // Deno-native unhandled-rejection reporting.
+      globalThis.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+        const reason = event.reason;
+        const message = reason instanceof Error ? reason.message : String(reason);
+        this.logger?.error(`Unhandled rejection: ${message}`);
+      });
+    } else {
+      // Node.js has no `globalThis.addEventListener` for process events;
+      // Bun implements this same `process.on` API.
+      process.on('unhandledRejection', (reason: unknown) => {
+        const message = reason instanceof Error ? reason.message : String(reason);
+        this.logger?.error(`Unhandled rejection: ${message}`);
+      });
+    }
 
     this.logger?.debug('Shutdown handler initialized');
   }
@@ -106,9 +129,14 @@ export class ShutdownHandler {
    * Stops listening for shutdown signals
    */
   unlisten(): void {
+    const isDeno = typeof Deno !== 'undefined';
     for (const [signal, handler] of this.signalHandlers) {
       try {
-        Deno.removeSignalListener(signal, handler);
+        if (isDeno) {
+          Deno.removeSignalListener(signal, handler);
+        } else {
+          process.off(signal, handler);
+        }
       } catch {
         // Signal may not have been registered
       }

--- a/src/adblock-compiler-core/src/utils/logger.ts
+++ b/src/adblock-compiler-core/src/utils/logger.ts
@@ -1,10 +1,20 @@
 // deno-lint-ignore-file no-console
 /**
  * Deno-native logger implementation
- * Replaces consola for Deno compatibility
+ * Replaces consola for Deno compatibility. Environment-variable reads
+ * (`createLoggerFromEnv`) also work under Node.js and Bun via `node:process`.
  */
 
+import process from 'node:process';
 import type { ILogger } from '../types/index.ts';
+
+/**
+ * Reads an environment variable, preferring Deno's API when available and
+ * falling back to `node:process` (Node.js and Bun) otherwise.
+ */
+function getEnvVar(name: string): string | undefined {
+  return typeof Deno !== 'undefined' && Deno.env ? Deno.env.get(name) : process.env[name];
+}
 
 /**
  * Log levels for filtering output
@@ -328,9 +338,7 @@ export function createLogger(options?: LoggerOptions): Logger {
 export function createLoggerFromEnv(options?: LoggerOptions): Logger {
   // Parse default log level from environment
   let defaultLevel = LogLevel.Info;
-  const envLevelRaw = typeof Deno !== 'undefined' && Deno.env
-    ? Deno.env.get('LOG_LEVEL')
-    : undefined;
+  const envLevelRaw = getEnvVar('LOG_LEVEL');
   const envLevel = envLevelRaw?.toLowerCase();
   if (envLevel) {
     switch (envLevel) {
@@ -357,15 +365,11 @@ export function createLoggerFromEnv(options?: LoggerOptions): Logger {
   }
 
   // Parse module overrides from environment
-  const envOverrides = typeof Deno !== 'undefined' && Deno.env
-    ? Deno.env.get('LOG_MODULE_OVERRIDES')
-    : undefined;
+  const envOverrides = getEnvVar('LOG_MODULE_OVERRIDES');
   const moduleOverrides = parseModuleOverrides(envOverrides);
 
   // Parse structured flag from environment
-  const envStructured = typeof Deno !== 'undefined' && Deno.env
-    ? Deno.env.get('LOG_STRUCTURED')
-    : undefined;
+  const envStructured = getEnvVar('LOG_STRUCTURED');
   const structured = envStructured === 'true' || envStructured === '1';
 
   // Merge with provided options (provided options take precedence)

--- a/src/adblock-compiler-core/src/version.ts
+++ b/src/adblock-compiler-core/src/version.ts
@@ -8,7 +8,7 @@ export const VERSION = '1.0.0';
 export const PACKAGE_NAME = '@bloqr/compiler-core';
 
 /** A `name/version` User-Agent string identifying this package, suitable for HTTP requests. */
-export const USER_AGENT = `${PACKAGE_NAME}/${VERSION}`;
+export const USER_AGENT: string = `${PACKAGE_NAME}/${VERSION}`;
 
 /** Convenience bundle of {@linkcode PACKAGE_NAME}, {@linkcode VERSION}, and {@linkcode USER_AGENT}. */
 export const PACKAGE_INFO = {


### PR DESCRIPTION
## Summary

`@bloqr/compiler-core` was Deno-native with only *incidental* Bun/Node compatibility — a handful of "works because Bun implements Node's fs/process" comments, but nothing verified against a real Bun install. Several code paths were actually Deno-only in practice and would throw under Bun/Node:

- `getVersionInfo()`/`showVersion()` (`cli.ts`) and `showVersionInfo()` (`console/app.ts`) called `Deno.version`/`Deno.build` directly — `ReferenceError` under Bun/Node on `--version` and the interactive console's Version Info menu item.
- `main()`'s default args and `findDefaultConfig()`'s default base path defaulted to `Deno.args`/`Deno.cwd()` directly.
- Several env-var readers (`utils/logger.ts`, `orchestration/logger.ts`, `configuration/sources/index.ts`) guarded against crashing but silently dropped `DEBUG`/`LOG_LEVEL`/`LOG_FORMAT`/etc. support under Bun/Node instead of falling back to `process.env`.
- `ShutdownHandler` (`orchestration/shutdown.ts`), despite being documented "Deno-only", called `globalThis.addEventListener('unhandledrejection', ...)` unconditionally — Node.js does not implement this at all, so it would throw on every CLI-mode invocation under Node.js.

All of the above now branch on `typeof Deno !== 'undefined'` and fall back to `node:process` (which Bun implements natively — no actual Node.js runtime involved) otherwise.

## Changes

- Added `src/mod.bun.ts` as the explicit Bun entry point (mirrors `src/mod.ts`, the Deno entry point), exported as the `./bun` `deno.json` subpath.
- Added a `bun-support` CI job (`typescript.yml`) that installs this package's JSR/npm dependencies for Bun (via `bunx jsr add`, JSR's own documented Bun installer bridge) and runs CLI + library smoke tests against **real Bun** on every PR — not just asserted in docs.
- Updated `README.md` with a "Bun (Supported)" section and `CHANGELOG.md`/root `CLAUDE.md` accordingly (including a new "TypeScript runtime/package-manager order of preference" policy section: Deno-native first, JSR before npm, Bun as a formally supported target, pnpm only when genuinely needed, Cloudflare Workers as the cloud-native deploy target).

## Unrelated fix included

While verifying `deno publish --dry-run` for this change, found `version.ts`'s `USER_AGENT` export was missing an explicit type annotation, which JSR's slow-types checker rejects. Confirmed this fails on the current `main` branch too (unrelated to this PR) and has been silently failing `publish-jsr.yml`'s dry-run gate on every push. One-line fix (`: string` annotation) included here since it was blocking verification of this PR's own dry-run.

## Test plan

- [x] `deno task check` / `deno task lint` / `deno fmt --check` / `deno task test` (1008/1008 passing) all green under Deno.
- [x] `deno publish --dry-run` succeeds (previously failing on `main`, see above).
- [x] Verified end-to-end against a real Bun install (not just `deno check`): `bun run src/mod.bun.ts --version` correctly self-identifies as `Runtime: Bun x.y.z`; `--validate` succeeds against the real sample config; `DEBUG=1 LOG_LEVEL=debug` env vars work; the library's `compile()` produces correct compiled+deduplicated output.
- [x] New `bun-support` CI job runs the exact same commands I verified locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Njq8s2j9cXsSBoYMjocwHN)_